### PR TITLE
Fix build errors in the dev-env

### DIFF
--- a/Containerfile.dev
+++ b/Containerfile.dev
@@ -22,7 +22,9 @@ FROM docker.io/golang:1.23.0-alpine3.19
 RUN apk add --no-cache \
 	bash git perl-utils zip \
 	&& \
-	echo "alias gask='go run tasks.go'" >~/.bashrc
+	echo "alias gask='go run tasks.go'" >~/.bashrc \
+	&& \
+	git config --global --add safe.directory /ghasum
 
 WORKDIR /ghasum
 COPY go.mod go.sum ./


### PR DESCRIPTION
## Summary

At some point building in the container started failing with the error:

```
error obtaining VCS status: exit status 128
        Use -buildvcs=false to disable VCS stamping.
```

this fixes that by adding the project directory inside the container as a folder trusted by git so that the Go compiler can get the VCS information.

An alternative would be to disable the VCS stamping, but it seems pretty useful to me to have this information available through `go version -m ./ghasum` for debugging purposes.