### PR TITLE
Harden GitHub Actions workflows

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -23,6 +23,8 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4.2.0
+      with:
+        persist-credentials: false
     - name: Install Go
       uses: actions/setup-go@v5.1.0
       with:
@@ -42,6 +44,8 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4.2.0
+      with:
+        persist-credentials: false
     - name: Install Go
       uses: actions/setup-go@v5.1.0
       with:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4.2.0
+      with:
+        persist-credentials: false
     - name: Install Go
       uses: actions/setup-go@v5.1.0
       with:
@@ -35,6 +37,8 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4.2.0
+      with:
+        persist-credentials: false
     - name: Install Go
       uses: actions/setup-go@v5.1.0
       with:
@@ -60,6 +64,8 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4.2.0
+      with:
+        persist-credentials: false
     - name: Install Go
       uses: actions/setup-go@v5.1.0
       with:
@@ -81,6 +87,8 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4.2.0
+      with:
+        persist-credentials: false
     - name: Install Go
       uses: actions/setup-go@v5.1.0
       with:
@@ -102,6 +110,8 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4.2.0
+      with:
+        persist-credentials: false
     - name: Install Go
       uses: actions/setup-go@v5.1.0
       with:
@@ -123,6 +133,8 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4.2.0
+      with:
+        persist-credentials: false
     - name: Install Go
       uses: actions/setup-go@v5.1.0
       with:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -16,6 +16,8 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4.2.0
+      with:
+        persist-credentials: false
     - name: Install Go
       uses: actions/setup-go@v5.1.0
       with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4.2.0
+      with:
+        persist-credentials: false
     - name: Install Go
       uses: actions/setup-go@v5.1.0
       with:

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4.2.0
+      with:
+        persist-credentials: false
     - name: Install Go
       uses: actions/setup-go@v5.1.0
       with:


### PR DESCRIPTION
## Summary

Update all GitHub Actions workflows following an analysis by [`zizmor`](https://github.com/woodruffw/zizmor). In particular, this avoids persisting git credentials when the job does not need it (which I believe is all but one job, which is a job that makes commits).
