### PR TITLE
Try out the CodeQL community queries for Go

### DIFF
--- a/.github/codeql.yml
+++ b/.github/codeql.yml
@@ -1,0 +1,10 @@
+# Configuration file for CodeQL (https://codeql.github.com/)
+
+name: ghasum CodeQL config
+
+packs:
+  - githubsecuritylab/codeql-go-libs@0.2.0
+  - githubsecuritylab/codeql-go-queries@0.2.0
+
+queries:
+  - uses: security-extended

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -32,6 +32,7 @@ jobs:
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v3.28.0
       with:
+        config-file: ./.github/codeql.yml
         languages: go
     - name: Perform CodeQL analysis
       uses: github/codeql-action/analyze@v3.28.0


### PR DESCRIPTION
As announced in:
<https://github.blog/security/vulnerability-research/announcing-codeql-community-packs/>

If this is merged an issue should be created regarding finding a strategy for keeping CodeQL packs up-to-date, because the packs are pinned to an exact version.