### PR TITLE
Bump Go from 1.23.5 to 1.23.6

### DIFF
--- a/Containerfile.dev
+++ b/Containerfile.dev
@@ -17,7 +17,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-FROM docker.io/golang:1.23.5-alpine3.21
+FROM docker.io/golang:1.23.6-alpine3.21
 
 RUN apk add --no-cache \
 	bash git perl-utils zip \

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/chains-project/ghasum
 
-go 1.23.5
+go 1.23.6
 
 require (
 	4d63.com/gochecknoinits v0.0.0-20210416043744-25bb07f6e4e3


### PR DESCRIPTION
Relates to #92, [Audit / Vulnerabilities #580](https://github.com/chains-project/ghasum/actions/runs/13192148515)

## Summary

Upgrade from Go 1.23.5 to 1.23.6 to receive 1 security-related update for the standard library that affect this codebase according to [govulncheck](https://pkg.go.dev/golang.org/x/vuln/cmd/govulncheck).

The relevant security ID is [`GO-2025-3447`](https://pkg.go.dev/vuln/GO-2025-3447).