### PR TITLE
Bump Go from 1.24.0 to 1.24.2

### DIFF
--- a/Containerfile.dev
+++ b/Containerfile.dev
@@ -17,7 +17,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-FROM docker.io/golang:1.24.0-alpine3.21
+FROM docker.io/golang:1.24.2-alpine3.21
 
 RUN apk add --no-cache \
 	bash git perl-utils zip \

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/chains-project/ghasum
 
-go 1.24.0
+go 1.24.2
 
 require (
 	github.com/go-git/go-git/v5 v5.14.0


### PR DESCRIPTION
Relates to #185, https://github.com/chains-project/ghasum/actions/runs/14371320698

## Summary

Bump to Go language version from 1.24.0 to 1.24.2 due to [GO-2025-3563](https://pkg.go.dev/vuln/GO-2025-3563).