### PR TITLE
Replace Semgrep PRO with Semgrep OSS

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,5 +1,6 @@
 name: Semgrep
 on:
+  pull_request: ~
   push:
     branches:
     - main
@@ -31,9 +32,7 @@ jobs:
         WORKFLOW=$(echo "$WORKFLOW" | cut -d '@' -f 1 | cut -d '/' -f 3-5)
         go run ./cmd/ghasum verify -cache /__w/_actions -no-evict -offline "$WORKFLOW:$JOB"
     - name: Perform Semgrep analysis
-      run: semgrep ci --sarif --output semgrep.sarif
-      env:
-        SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
+      run: semgrep --sarif --output semgrep.sarif
     - name: Upload Semgrep report to GitHub
       uses: github/codeql-action/upload-sarif@v3.28.5
       if: ${{ failure() || success() }}


### PR DESCRIPTION
## Summary

This updates the [`semgrep.yml` workflow](https://github.com/chains-project/ghasum/blob/40f7fe7d3f4efef1abf8ae60967037d881d62771/.github/workflows/semgrep.yml#L36) to run Semgrep OSS instead of Semgrep PRO. The tradeoff here is giving up some SAST rules and SSC support in favor of not needing an authentication token, running for all changes, allowing anyone to perform the scan locally, and no dependence on the availability of the Semgrep backend. Not to mention that we have SSC support covered through [other means](https://github.com/chains-project/ghasum/blob/40f7fe7d3f4efef1abf8ae60967037d881d62771/tasks.go#L68).