### PR TITLE
Compute checksums for transitive Actions

### DIFF
--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -6,10 +6,95 @@ The specification aims to clarify how `ghasum` operates. Any discrepancy with
 the implementation or ambiguity in the specification can be reported as a bug.
 There is no guarantee on whether the specification or implementation is correct.
 
-## Scope
+## Actions
 
-The scope of `ghasum` are reusable GitHub Actions used in the GitHub Actions
-Workflow of a repository. This excludes
+### `ghasum init`
+
+If the checksum file exists the process shall exit immediately with an error.
+
+If the checksum file does not exist the process creates it immediately and
+obtains a lock on it. If this is not possible the process should exit
+immediately (it means either 1. the file has been created since it was checked
+and so is not owned by us, or 2. the file could not be created and so cannot be
+initialized).
+
+If the file lock is obtained, the process will compute checksums (see [Computing
+Checksums]) for all actions used in the repository (see [Collecting Actions])
+using the best available hashing algorithm. Then it stores them in a sumfile
+(see [Storing Checksums]) using the latest sumfile version. Finally the process
+will releases the lock on the file.
+
+If the process fails an attempt should be made to remove the created file (if
+removing fails the error is ignored).
+
+### `ghasum update`
+
+If the checksum file does not exist the process shall exit immediately with an
+error.
+
+If the checksum file exists the process shall obtain a lock on it, if this is
+not possible to process shall exit immediately (it means the file may be edited
+by another process leading to an inconsistent state).
+
+If the file lock is obtained, the process shall first read it and parse it
+completely to extract the sumfile version. If this fails the process shall exit
+immediately unless the `-force` flag is used (see details below). Else it shall
+compute checksums (see [Computing Checksums]) for all new actions used in the
+repository (see [Collecting Actions]) using the same hashing algorithm as was
+used for the existing checksums. New actions also include new versions of a
+previously used actions. Additionally, it should remove any entry which is no
+longer in use. No existing checksum for a used action shall be updated. It shall
+then store them in a sumfile (see [Storing Checksums]) using the same sumfile
+version as before and releases the lock. In short, updating will only add new
+and remove old checksums from an existing sumfile.
+
+With the `-force` flag the process will ignore errors in the sumfile and fix
+those while updating. It will also update existing checksums that are incorrect.
+If the sumfile version can still be determined from sumfile it will be used,
+otherwise the latest available version is used instead. This option is disabled
+by default to avoid unknowingly fixing syntax or other errors in a sumfile,
+which is an important fact to know about from a security perspective.
+
+This process does not verify any of the checksums currently in the sumfile.
+
+### `ghasum verify`
+
+If the checksum file does not exist the process shall exit immediately with an
+error.
+
+If the checksum file exists the process shall read and parse it fully. If this
+fails the process shall exit immediately. Else it shall recompute the checksums
+(see [Computing Checksums]) for all actions in the target (see [Collecting
+Actions]) using the same hashing algorithm as was used for the stored checksums.
+It shall compare the computed checksums against the stored checksums.
+
+If any of the checksums does not match or is missing the process shall exit with
+a non-zero exit code, for usability all values should be compared (and all
+mismatches reported) before exiting.
+
+The "target" can be one of a: a repository, a workflow, or a job. If the target
+is a repository, all actions used in all jobs in all workflows in the repository
+will be considered. If the target is a workflow, only actions used in all jobs
+in the workflow will be considered. If the target is a job, only actions used in
+the job will be considered.
+
+Redundant checksums are ignored by this process.
+
+## Procedures
+
+### Collecting Actions
+
+To determine the set of actions a target depends on, first find all `uses:`
+entries in the target. For a repository this covers all workflows in the
+workflows directory, otherwise it covers only the target.
+
+For each `uses:` value, excluding the list below, it is added to the set and the
+repository declared by the `uses:` value is fetched. The action manifest at the
+path specified in the `uses:` value is parsed for additional `uses:` values. For
+each of these transitive `uses:` values, this process is repeated.
+
+The following `uses:` values are to be excluded from the set of actions a
+repository depends on.
 
 - Actions in the same repository as the workflow ("local actions"). Example:
 
@@ -41,81 +126,6 @@ Workflow of a repository. This excludes
 
 [#215]: https://github.com/chains-project/ghasum/issues/215
 [#216]: https://github.com/chains-project/ghasum/issues/216
-
-## Actions
-
-### `ghasum init`
-
-If the checksum file exists the process shall exit immediately with an error.
-
-If the checksum file does not exist the process creates it immediately and
-obtains a lock on it. If this is not possible the process should exit
-immediately (it means either 1. the file has been created since it was checked
-and so is not owned by us, or 2. the file could not be created and so cannot be
-initialized).
-
-If the file lock is obtained, the process will compute checksums for all actions
-used in the repository (see [Computing Checksums]) using the best available
-hashing algorithm. Then it stores them in a sumfile (see [Storing Checksums])
-using the latest sumfile version and releases the lock.
-
-If the process fails an attempt should be made to remove the created file (if
-removing fails the error is ignored).
-
-### `ghasum update`
-
-If the checksum file does not exist the process shall exit immediately with an
-error.
-
-If the checksum file exists the process shall obtain a lock on it, if this is
-not possible to process shall exit immediately (it means the file may be edited
-by another process leading to an inconsistent state).
-
-If the file lock is obtained, the process shall first read it and parse it
-completely to extract the sumfile version. If this fails the process shall exit
-immediately unless the `-force` flag is used (see details below). Else it shall
-compute checksums for all new actions used in the repository (see [Computing
-Checksums]) using the best available hashing algorithm. Here, a new action also
-includes a new version of a previously used action. Additionally, it should
-remove any entry which is no longer in use. No existing checksum for a used
-action shall be updated unless the `-force` flag is used. It shall then store
-them in a sumfile (see [Storing Checksums]) using the same sumfile version as
-before and releases the lock. In short, updating will only add new and remove
-old checksums from an existing sumfile.
-
-With the `-force` flag the process will ignore errors in the sumfile and fix
-those while updating. It will also update existing checksums that are incorrect.
-If the sumfile version can still be determined from sumfile it will be used,
-otherwise the latest available version is used instead. This option is disabled
-by default to avoid unknowingly fixing syntax or other errors in a sumfile,
-which is an important fact to know about from a security perspective.
-
-This process does not verify any of the checksums currently in the sumfile.
-
-### `ghasum verify`
-
-If the checksum file does not exist the process shall exit immediately with an
-error.
-
-If the checksum file exists the process shall read and parse it fully. If this
-fails the process shall exit immediately. Else it shall recompute the checksums
-(see [Computing Checksums]) for all actions in the target using the same hashing
-algorithm as was used for the stored checksums. It shall compare the computed
-checksums against the stored checksums.
-
-If any of the checksums does not match or is missing the process shall exit with
-a non-zero exit code, for usability all values should be compared (and all
-mismatches reported) before exiting.
-
-The "target" can be one of a: a repository, a workflow, or a job. If the target
-is a repository, all actions used in all jobs in all workflows in the repository
-will be considered. If the target is a workflow, only actions used in all jobs
-in the workflow will be considered. If the target is a job, only actions used in
-the job will be considered.
-
-Redundant checksums are ignored by this process.
-
-## Procedures
 
 ### Computing Checksums
 
@@ -181,8 +191,12 @@ version 1
 
 ## Definitions
 
+- _action manifest_ is the file `action.yml` or `action.yaml` (mutually
+  exclusive).
 - _checksum file_ is the file `.github/workflows/gha.sum`.
+- _workflows directory_ is the directory `.github/workflows`.
 
+[collecting actions]: #collecting-actions
 [computing checksums]: #computing-checksums
 [storing checksums]: #storing-checksums
 [sumfile versions]: #sumfile-versions

--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -88,10 +88,11 @@ To determine the set of actions a target depends on, first find all `uses:`
 entries in the target. For a repository this covers all workflows in the
 workflows directory, otherwise it covers only the target.
 
-For each `uses:` value, excluding the list below, it is added to the set and the
-repository declared by the `uses:` value is fetched. The action manifest at the
-path specified in the `uses:` value is parsed for additional `uses:` values. For
-each of these transitive `uses:` values, this process is repeated.
+For each `uses:` value, excluding the list below, it is added to the set. If the
+`-no-transitive` option is NOT set the repository declared by the `uses:` value
+is fetched. The action manifest at the path specified in the `uses:` value is
+parsed for additional `uses:` values. For each of these transitive `uses:`
+values, this process is repeated.
 
 The following `uses:` values are to be excluded from the set of actions a
 repository depends on.

--- a/cmd/ghasum/init.go
+++ b/cmd/ghasum/init.go
@@ -26,9 +26,10 @@ import (
 
 func cmdInit(argv []string) error {
 	var (
-		flags       = flag.NewFlagSet(cmdNameInit, flag.ContinueOnError)
-		flagCache   = flags.String(flagNameCache, "", "")
-		flagNoCache = flags.Bool(flagNameNoCache, false, "")
+		flags            = flag.NewFlagSet(cmdNameInit, flag.ContinueOnError)
+		flagCache        = flags.String(flagNameCache, "", "")
+		flagNoCache      = flags.Bool(flagNameNoCache, false, "")
+		flagNoTransitive = flags.Bool(flagNameNoTransitive, false, "")
 	)
 
 	flags.Usage = func() { fmt.Fprintln(os.Stderr) }
@@ -57,9 +58,10 @@ func cmdInit(argv []string) error {
 	}
 
 	cfg := ghasum.Config{
-		Repo:  repo.FS(),
-		Path:  target,
-		Cache: c,
+		Repo:       repo.FS(),
+		Path:       target,
+		Cache:      c,
+		Transitive: !(*flagNoTransitive),
 	}
 
 	if err := ghasum.Initialize(&cfg); err != nil {
@@ -84,5 +86,7 @@ The available flags are:
         looks up repositories it needs.
         Defaults to a directory named .ghasum in the user's home directory.
     -no-cache
-        Disable the use of the cache. Makes the -cache flag ineffective.`
+        Disable the use of the cache. Makes the -cache flag ineffective.
+    -no-transitive
+        Do not compute checksums for transitive actions.`
 }

--- a/cmd/ghasum/main.go
+++ b/cmd/ghasum/main.go
@@ -45,11 +45,12 @@ const (
 )
 
 const (
-	flagNameCache   = "cache"
-	flagNameForce   = "force"
-	flagNameNoCache = "no-cache"
-	flagNameNoEvict = "no-evict"
-	flagNameOffline = "offline"
+	flagNameCache        = "cache"
+	flagNameForce        = "force"
+	flagNameNoCache      = "no-cache"
+	flagNameNoEvict      = "no-evict"
+	flagNameNoTransitive = "no-transitive"
+	flagNameOffline      = "offline"
 )
 
 var (

--- a/cmd/ghasum/update.go
+++ b/cmd/ghasum/update.go
@@ -26,11 +26,12 @@ import (
 
 func cmdUpdate(argv []string) error {
 	var (
-		flags       = flag.NewFlagSet(cmdNameUpdate, flag.ContinueOnError)
-		flagCache   = flags.String(flagNameCache, "", "")
-		flagForce   = flags.Bool(flagNameForce, false, "")
-		flagNoCache = flags.Bool(flagNameNoCache, false, "")
-		flagNoEvict = flags.Bool(flagNameNoEvict, false, "")
+		flags            = flag.NewFlagSet(cmdNameUpdate, flag.ContinueOnError)
+		flagCache        = flags.String(flagNameCache, "", "")
+		flagForce        = flags.Bool(flagNameForce, false, "")
+		flagNoCache      = flags.Bool(flagNameNoCache, false, "")
+		flagNoEvict      = flags.Bool(flagNameNoEvict, false, "")
+		flagNoTransitive = flags.Bool(flagNameNoTransitive, false, "")
 	)
 
 	flags.Usage = func() { fmt.Fprintln(os.Stderr) }
@@ -65,9 +66,10 @@ func cmdUpdate(argv []string) error {
 	}
 
 	cfg := ghasum.Config{
-		Repo:  repo.FS(),
-		Path:  target,
-		Cache: c,
+		Repo:       repo.FS(),
+		Path:       target,
+		Cache:      c,
+		Transitive: !(*flagNoTransitive),
 	}
 
 	if err := ghasum.Update(&cfg, *flagForce); err != nil {
@@ -98,5 +100,7 @@ The available flags are:
     -no-cache
         Disable the use of the cache. Makes the -cache flag ineffective.
     -no-evict
-        Disable cache eviction.`
+        Disable cache eviction.
+    -no-transitive
+        Do not compute checksums for transitive actions.`
 }

--- a/cmd/ghasum/verify.go
+++ b/cmd/ghasum/verify.go
@@ -29,11 +29,12 @@ import (
 
 func cmdVerify(argv []string) error {
 	var (
-		flags       = flag.NewFlagSet(cmdNameVerify, flag.ContinueOnError)
-		flagCache   = flags.String(flagNameCache, "", "")
-		flagNoCache = flags.Bool(flagNameNoCache, false, "")
-		flagNoEvict = flags.Bool(flagNameNoEvict, false, "")
-		flagOffline = flags.Bool(flagNameOffline, false, "")
+		flags            = flag.NewFlagSet(cmdNameVerify, flag.ContinueOnError)
+		flagCache        = flags.String(flagNameCache, "", "")
+		flagNoCache      = flags.Bool(flagNameNoCache, false, "")
+		flagNoEvict      = flags.Bool(flagNameNoEvict, false, "")
+		flagOffline      = flags.Bool(flagNameOffline, false, "")
+		flagNoTransitive = flags.Bool(flagNameNoTransitive, false, "")
 	)
 
 	flags.Usage = func() { fmt.Fprintln(os.Stderr) }
@@ -86,12 +87,13 @@ func cmdVerify(argv []string) error {
 	}
 
 	cfg := ghasum.Config{
-		Repo:     repo.FS(),
-		Path:     target,
-		Workflow: workflow,
-		Job:      job,
-		Cache:    c,
-		Offline:  *flagOffline,
+		Repo:       repo.FS(),
+		Path:       target,
+		Workflow:   workflow,
+		Job:        job,
+		Cache:      c,
+		Offline:    *flagOffline,
+		Transitive: !(*flagNoTransitive),
 	}
 
 	problems, err := ghasum.Verify(&cfg)
@@ -151,5 +153,7 @@ The available flags are:
         Disable cache eviction.
     -offline
         Run without fetching repositories from the internet, verify exclusively
-        against the cache. If the cache is missing an entry it causes an error.`
+        against the cache. If the cache is missing an entry it causes an error.
+    -no-transitive
+        Do not compute checksums for transitive actions.`
 }

--- a/cmd/ghasum/version.go
+++ b/cmd/ghasum/version.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Eric Cornelissen
+// Copyright 2024-2025 Eric Cornelissen
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/gha/parse.go
+++ b/internal/gha/parse.go
@@ -22,6 +22,14 @@ import (
 )
 
 type (
+	manifest struct {
+		Runs runs `yaml:"runs"`
+	}
+
+	runs struct {
+		Steps []step `yaml:"steps"`
+	}
+
 	workflow struct {
 		Jobs map[string]job `yaml:"jobs"`
 	}
@@ -34,6 +42,15 @@ type (
 		Uses string `yaml:"uses"`
 	}
 )
+
+func parseManifest(data []byte) (manifest, error) {
+	var m manifest
+	if err := yaml.Unmarshal(data, &m); err != nil {
+		return m, fmt.Errorf("could not parse manifest: %v", err)
+	}
+
+	return m, nil
+}
 
 func parseWorkflow(data []byte) (workflow, error) {
 	var w workflow
@@ -78,6 +95,7 @@ func parseUses(uses string) (GitHubAction, error) {
 	if i == 0 || i == len(project)-1 {
 		return a, ErrInvalidUsesPath
 	} else if i > 0 && i < len(project)-1 {
+		a.Path = project[i+1:]
 		project = project[:i]
 	}
 

--- a/internal/gha/shared_test.go
+++ b/internal/gha/shared_test.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Eric Cornelissen
+// Copyright 2024-2025 Eric Cornelissen
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -32,7 +32,27 @@ type mockFsEntry struct {
 }
 
 const (
-	workflowWithNoJobs     = `name: no jobs`
+	manifestWithNoSteps = `name: manifest with no steps`
+	manifestWithStep    = `name: manifest with no steps
+runs:
+  steps:
+    - uses: foo/bar@v1
+    - name: no uses
+    - uses: foo/baz@v2
+`
+	manifestWithNestedActions = `name: job using an action that is not at the root
+runs:
+  steps:
+    - uses: nested/action/1@v1
+    - uses: nested/action/2@v1
+`
+	manifestWithInvalidUses = `name: invalid 'uses' value
+runs:
+  steps:
+    - uses: this-is-not-an-action
+`
+
+	workflowWithNoJobs     = `name: workflow with no jobs`
 	workflowWithJobNoSteps = `name: job without steps
 jobs:
   no-steps: ~
@@ -62,24 +82,19 @@ jobs:
       - uses: nested/action/1@v1
       - uses: nested/action/2@v1
 `
-	workflowWithSyntaxError = `Hello world!`
 	workflowWithInvalidUses = `name: invalid 'uses' value
 jobs:
   job:
     steps:
       - uses: this-is-not-an-action
 `
+
+	yamlWithSyntaxError = `Hello world!`
 )
 
 func mockRepo(entries map[string]mockFsEntry) (fs.FS, error) {
 	repo := memoryfs.New()
-
-	err := repo.MkdirAll(WorkflowsPath, 0o700)
-	if err != nil {
-		return nil, fmt.Errorf("failed to initialize workflows directory: %v", err)
-	}
-
-	err = mockRepoInternal(repo, WorkflowsPath, entries)
+	err := mockRepoInternal(repo, ".", entries)
 	return repo, err
 }
 

--- a/internal/ghasum/atoms.go
+++ b/internal/ghasum/atoms.go
@@ -128,11 +128,13 @@ func compute(cfg *Config, actions []gha.GitHubAction, algo checksum.Algo) ([]sum
 			}
 		}
 
-		transitiveActions, err := gha.ManifestActions(os.DirFS(actionDir), action.Path)
-		if err != nil {
-			return nil, fmt.Errorf("action manifest parsing failed: %v", err)
+		if cfg.Transitive {
+			transitiveActions, err := gha.ManifestActions(os.DirFS(actionDir), action.Path)
+			if err != nil {
+				return nil, fmt.Errorf("action manifest parsing failed: %v", err)
+			}
+			actions = append(actions, transitiveActions...)
 		}
-		actions = append(actions, transitiveActions...)
 
 		id := fmt.Sprintf("%s%s%s", action.Owner, action.Project, action.Ref)
 		if _, ok := entries[id]; !ok {

--- a/internal/ghasum/operations.go
+++ b/internal/ghasum/operations.go
@@ -28,36 +28,41 @@ import (
 type (
 	// Config is the configuration for a ghasum operation.
 	Config struct {
-		// Repo is a pointer to the file system hierarchy of the target repository
-		// for the operation.
+		// Repo is a pointer to the file system hierarchy of the target
+		// repository for the operation.
 		Repo fs.FS
 
 		// Path is the absolute or relate path to the target repository for the
 		// operation.
 		//
-		// This must be provided in addition to Repo because that does not allow for
-		// non-read file system operation.
+		// This must be provided in addition to Repo because that does not allow
+		// for non-read file system operation.
 		Path string
 
-		// Workflow is the file path (relative to Path) of the workflow that is the
-		// subject of the operation. If this has the zero value all workflows in the
-		// Repo will collectively be the subject of the operation instead.
+		// Workflow is the file path (relative to Path) of the workflow that is
+		// the subject of the operation. If this has the zero value all of the
+		// workflows in the Repo will collectively be the subject of the
+		// operation instead.
 		Workflow string
 
-		// Job is the id (also known as key) of the job that is the subject of the
-		// operation. If this has the zero value all jobs in the Workflow will
-		// collectively be the subject of the operation instead. (If Workflow has
-		// the zero value this value is ignored.)
+		// Job is the id (also known as key) of the job that is the subject of
+		// the operation. If this has the zero value all jobs in the Workflow
+		// will collectively be the subject of the operation instead. (If
+		// Workflow has the zero value this value is ignored.)
 		Job string
 
 		// Cache is the cache that should be used for the operation.
 		Cache cache.Cache
 
-		// Offline sets whether to rely exclusively on the cache or fetch missing
-		// repositories from the internet.
+		// Offline sets whether to rely exclusively on the cache or fetch
+		// missing repositories from the internet.
 		//
 		// Only applies to verification.
 		Offline bool
+
+		// Transitive sets whether to compute/verify checksums for transitive
+		// dependencies.
+		Transitive bool
 	}
 
 	// Problem represents an issue detected when verifying ghasum checksums.

--- a/internal/github/clone.go
+++ b/internal/github/clone.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Eric Cornelissen
+// Copyright 2024-2025 Eric Cornelissen
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tasks.go
+++ b/tasks.go
@@ -1,6 +1,6 @@
 // MIT No Attribution
 //
-// Copyright (c) 2024 Eric Cornelissen
+// Copyright (c) 2025 Eric Cornelissen
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/testdata/cache/success.txtar
+++ b/testdata/cache/success.txtar
@@ -22,9 +22,7 @@ exec ghasum cache -cache .cache/ path
 stdout .cache/
 ! stderr .
 
--- .cache/actions/checkout/v4/.keep --
-This file exist to avoid fetching "actions/checkout@v4" and give the Action a
-unique checksum.
--- .cache/actions/setup-go/v5/.keep --
-This file exists to avoid fetching "actions/setup-go@v5" and give the Action a
-unique checksum.
+-- .cache/actions/checkout/v4/action.yml --
+name: actions/checkout@v4
+-- .cache/actions/setup-go/v5/action.yml --
+name: actions/setup-go@v5

--- a/testdata/end-to-end.txtar
+++ b/testdata/end-to-end.txtar
@@ -47,15 +47,11 @@ jobs:
       uses: golangci/golangci-lint-action@3a91952
     - name: This step does not use an action
       run: Echo 'hello world!'
--- .cache/actions/checkout/main/.keep --
-This file exist to avoid fetching "actions/checkout@main" and give the Action a
-unique checksum.
--- .cache/actions/checkout/v4.1.1/.keep --
-This file exist to avoid fetching "actions/checkout@v4.1.1" and give the Action
-a unique checksum.
--- .cache/actions/setup-go/v5.0.0/.keep --
-This file exists to avoid fetching "actions/setup-go@v5.0.0" and give the Action
-a unique checksum.
--- .cache/golangci/golangci-lint-action/3a91952/.keep --
-This file exist to avoid fetching "golangci/golangci-lint-action@3a91952" and
-give the Action a unique checksum.
+-- .cache/actions/checkout/main/action.yml --
+name: actions/checkout@main
+-- .cache/actions/checkout/v4.1.1/action.yml --
+name: actions/checkout@v4.1.1
+-- .cache/actions/setup-go/v5.0.0/action.yml --
+name: actions/setup-go@v5.0.0
+-- .cache/golangci/golangci-lint-action/3a91952/action.yml --
+name: golangci/golangci-lint-action@3a91952

--- a/testdata/init/error.txtar
+++ b/testdata/init/error.txtar
@@ -26,9 +26,9 @@ stderr 'no such file or directory'
 -- initialized/.github/workflows/gha.sum --
 version 1
 
-actions/checkout@main PKruFKnotZi8RQ196H3R7c5bgw9+mfI7BN/h0A7XiV8=
-actions/setup-go@v5.0.0 7lPZupz84sSI3T+PiaMr/ML3XPqJaEo7dMaPsQUnM6c=
-golangci/golangci-lint-action@3a91952 CVRgC7gGqkOiujfm0VMRKppg/Ztv8FW9GYmyJzcwlCI=
+actions/checkout@main JHipZi1UCvybC3fwi9RFLTK8vpI/gURTga/ColyHI4k=
+actions/setup-go@v5.0.0 NoW6+RttcHeApXsFxN2DfY/2Oc7t0g9mgq22uJ3rAbg=
+golangci/golangci-lint-action@3a91952 Whvj26yZchrz2jiVS3IZrwZ2DXX71qu4gynanpV3G4I=
 -- initialized/.github/workflows/workflow.yml --
 name: Example workflow
 on: [push]

--- a/testdata/init/success.txtar
+++ b/testdata/init/success.txtar
@@ -4,6 +4,14 @@ stdout 'Ok'
 ! stderr .
 cmp target/.github/workflows/gha.sum want/gha.sum
 
+rm target/.github/workflows/gha.sum
+
+# Without transitive actions
+exec ghasum init -cache .cache/ -no-transitive target/
+stdout 'Ok'
+! stderr .
+cmp target/.github/workflows/gha.sum want/gha-no-transitive.sum
+
 -- want/gha.sum --
 version 1
 
@@ -11,6 +19,13 @@ actions/checkout@main JHipZi1UCvybC3fwi9RFLTK8vpI/gURTga/ColyHI4k=
 actions/composite@v1 a3ht0IImDEBC7NqbohfejBtv7W5GdKiGJgc4OtYkjEs=
 actions/setup-go@v5.0.0 NoW6+RttcHeApXsFxN2DfY/2Oc7t0g9mgq22uJ3rAbg=
 actions/setup-node@v4.4.0 Gdoys4h+gIN02lzrWZW0uxjBQ8Rk5YSE6+q1SOrw/+o=
+golangci/golangci-lint-action@3a91952 Whvj26yZchrz2jiVS3IZrwZ2DXX71qu4gynanpV3G4I=
+-- want/gha-no-transitive.sum --
+version 1
+
+actions/checkout@main JHipZi1UCvybC3fwi9RFLTK8vpI/gURTga/ColyHI4k=
+actions/composite@v1 a3ht0IImDEBC7NqbohfejBtv7W5GdKiGJgc4OtYkjEs=
+actions/setup-go@v5.0.0 NoW6+RttcHeApXsFxN2DfY/2Oc7t0g9mgq22uJ3rAbg=
 golangci/golangci-lint-action@3a91952 Whvj26yZchrz2jiVS3IZrwZ2DXX71qu4gynanpV3G4I=
 -- target/.github/workflows/workflow.yml --
 name: Example workflow

--- a/testdata/init/success.txtar
+++ b/testdata/init/success.txtar
@@ -7,9 +7,11 @@ cmp target/.github/workflows/gha.sum want/gha.sum
 -- want/gha.sum --
 version 1
 
-actions/checkout@main PKruFKnotZi8RQ196H3R7c5bgw9+mfI7BN/h0A7XiV8=
-actions/setup-go@v5.0.0 7lPZupz84sSI3T+PiaMr/ML3XPqJaEo7dMaPsQUnM6c=
-golangci/golangci-lint-action@3a91952 CVRgC7gGqkOiujfm0VMRKppg/Ztv8FW9GYmyJzcwlCI=
+actions/checkout@main JHipZi1UCvybC3fwi9RFLTK8vpI/gURTga/ColyHI4k=
+actions/composite@v1 a3ht0IImDEBC7NqbohfejBtv7W5GdKiGJgc4OtYkjEs=
+actions/setup-go@v5.0.0 NoW6+RttcHeApXsFxN2DfY/2Oc7t0g9mgq22uJ3rAbg=
+actions/setup-node@v4.4.0 Gdoys4h+gIN02lzrWZW0uxjBQ8Rk5YSE6+q1SOrw/+o=
+golangci/golangci-lint-action@3a91952 Whvj26yZchrz2jiVS3IZrwZ2DXX71qu4gynanpV3G4I=
 -- target/.github/workflows/workflow.yml --
 name: Example workflow
 on: [push]
@@ -27,18 +29,27 @@ jobs:
         go-version-file: go.mod
     - name: golangci-lint
       uses: golangci/golangci-lint-action@3a91952
+    - name: This step uses transitive actions
+      uses: actions/composite@v1
     - name: This step uses a local action
       uses: ./.github/actions/hello-world-action
     - name: This step uses a Docker Hub action
       uses: docker://alpine:3.8
     - name: This step does not use an action
       run: Echo 'hello world!'
--- .cache/actions/checkout/main/.keep --
-This file exist to avoid fetching "actions/checkout@main" and give the Action a
-unique checksum.
--- .cache/actions/setup-go/v5.0.0/.keep --
-This file exists to avoid fetching "actions/setup-go@v5.0.0" and give the Action
-a unique checksum.
--- .cache/golangci/golangci-lint-action/3a91952/.keep --
-This file exist to avoid fetching "golangci/golangci-lint-action@3a91952" and
-give the Action a unique checksum.
+-- .cache/actions/checkout/main/action.yml --
+name: actions/checkout@main
+-- .cache/actions/composite/v1/action.yml --
+name: actions/composite@v1
+runs:
+  steps:
+  - name: Also a direct dependency
+    uses: actions/setup-go@v5.0.0
+  - name: Unique transitive dependency
+    uses: actions/setup-node@v4.4.0
+-- .cache/actions/setup-go/v5.0.0/action.yml --
+name: actions/setup-go@v5.0.0
+-- .cache/actions/setup-node/v4.4.0/action.yml --
+name: actions/setup-node@v4.4.0
+-- .cache/golangci/golangci-lint-action/3a91952/action.yml --
+name: golangci/golangci-lint-action@3a91952

--- a/testdata/update/error.txtar
+++ b/testdata/update/error.txtar
@@ -44,12 +44,34 @@ stderr 'an unexpected error occurred'
 stderr 'could not parse workflow'
 stderr '.github/workflows/workflow.yml'
 
+# Invalid manifest
+! exec ghasum verify -cache .cache/ invalid-manifest/
+! stdout 'Ok'
+stderr 'an unexpected error occurred'
+stderr 'could not parse manifest'
+
 # Directory not found
 ! exec ghasum update directory-not-found/
 ! stdout 'Ok'
 stderr 'an unexpected error occurred'
 stderr 'no such file or directory'
 
+-- invalid-manifest/.github/workflows/gha.sum --
+version 1
+
+actions/composite@v1 sD5wRDv4rn1UBi0Mzs9jHAB++jiJuAVuggdh437FKHE=
+actions/setup-go@v5 Vi4XogAGoojozgoXrRN/OBL93QIcbsxLJEOOAwlx+e8=
+-- invalid-manifest/.github/workflows/workflow.yml --
+name: Faulty workflow
+on: [push]
+
+jobs:
+  example:
+    name: example
+    runs-on: ubuntu-24.04
+    steps:
+    - name: This step uses transitive actions
+      uses: actions/composite@v1
 -- invalid-workflow/.github/workflows/gha.sum --
 version 1
 
@@ -100,3 +122,11 @@ jobs:
         go-version-file: go.mod
     - name: This step does not use an action
       run: Echo 'hello world!'
+-- .cache/actions/composite/v1/action.yml --
+name: actions/composite@v1
+runs:
+  steps:
+- name: Also a direct dependency
+  uses: actions/setup-go@v5
+-- .cache/actions/setup-go/v5/action.yml --
+name: actions/setup-go@v5

--- a/testdata/update/force.txtar
+++ b/testdata/update/force.txtar
@@ -40,10 +40,16 @@ stdout 'Ok'
 ! stderr .
 cmp invalid-sum/.github/workflows/gha.sum .want/gha.sum
 
+# Invalid existing transitive sum
+exec ghasum update -cache .cache/ -force transitive/
+stdout 'Ok'
+! stderr .
+cmp transitive/.github/workflows/gha.sum .want/gha-transitive.sum
+
 -- duplicate/.github/workflows/gha.sum --
 version 1
 
-actions/checkout@v4.1.1 KsR9XQGH7ydTl01vlD8pIZrXhkzXyjcnzhmP+/KaJZI=
+actions/checkout@v4.1.1 TTVf+dWEJueFyMoZnvuqlW5lX4aXYXxGWaFaV8lO910=
 actions/checkout@v4.1.1 KaJZI=/KsR9XQGH7ydTl01vlD8pIZrXhkzXyjcnzhmP+
 -- duplicate/.github/workflows/workflow.yml --
 name: Example workflow
@@ -134,7 +140,7 @@ jobs:
 -- invalid-sum/.github/workflows/gha.sum --
 version 1
 
-actions/checkout@v4.1.1 GGAV+/JnlPt41B9iINyvcX5z6a4ue+NblmwiDNVORz0=
+actions/checkout@v4.1.1 this-is-intentionally-invalid
 -- invalid-sum/.github/workflows/workflow.yml --
 name: Example workflow
 on: [push]
@@ -146,10 +152,38 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4.1.1
--- .cache/actions/checkout/v4.1.1/.keep --
-This file exist to avoid fetching "actions/checkout@v4.1.1" and give the Action
-a unique checksum.
+-- transitive/.github/workflows/gha.sum --
+version 1
+
+actions/composite@v1 uc9AaN29Y4B/7UgwrQoYDYDlbJhua//0wr8eMLHqen8=
+actions/setup-node@v4.4.0 this-is-intentionally-invalid
+-- transitive/.github/workflows/workflow.yml --
+name: Example workflow
+on: [push]
+
+jobs:
+  example:
+    name: example
+    runs-on: ubuntu-24.04
+    steps:
+    - name: This step uses transitive actions
+      uses: actions/composite@v1
+-- .cache/actions/checkout/v4.1.1/action.yml --
+name: actions/checkout@v4.1.1
+-- .cache/actions/composite/v1/action.yml --
+name: actions/composite@v1
+runs:
+  steps:
+  - name: Unique transitive dependency
+    uses: actions/setup-node@v4.4.0
+-- .cache/actions/setup-node/v4.4.0/action.yml --
+name: actions/setup-node@v4.4.0
 -- .want/gha.sum --
 version 1
 
-actions/checkout@v4.1.1 KsR9XQGH7ydTl01vlD8pIZrXhkzXyjcnzhmP+/KaJZI=
+actions/checkout@v4.1.1 TTVf+dWEJueFyMoZnvuqlW5lX4aXYXxGWaFaV8lO910=
+-- .want/gha-transitive.sum --
+version 1
+
+actions/composite@v1 uc9AaN29Y4B/7UgwrQoYDYDlbJhua//0wr8eMLHqen8=
+actions/setup-node@v4.4.0 Gdoys4h+gIN02lzrWZW0uxjBQ8Rk5YSE6+q1SOrw/+o=

--- a/testdata/update/success.txtar
+++ b/testdata/update/success.txtar
@@ -33,21 +33,27 @@ cmp preserve/.github/workflows/gha.sum want/gha-preserve.sum
 -- want/gha.sum --
 version 1
 
-actions/checkout@v4.1.1 KsR9XQGH7ydTl01vlD8pIZrXhkzXyjcnzhmP+/KaJZI=
-actions/setup-go@v5.0.0 7lPZupz84sSI3T+PiaMr/ML3XPqJaEo7dMaPsQUnM6c=
-golangci/golangci-lint-action@3a91952 CVRgC7gGqkOiujfm0VMRKppg/Ztv8FW9GYmyJzcwlCI=
+actions/checkout@v4.1.1 TTVf+dWEJueFyMoZnvuqlW5lX4aXYXxGWaFaV8lO910=
+actions/composite@v1 a3ht0IImDEBC7NqbohfejBtv7W5GdKiGJgc4OtYkjEs=
+actions/setup-go@v5.0.0 NoW6+RttcHeApXsFxN2DfY/2Oc7t0g9mgq22uJ3rAbg=
+actions/setup-node@v4.4.0 Gdoys4h+gIN02lzrWZW0uxjBQ8Rk5YSE6+q1SOrw/+o=
+golangci/golangci-lint-action@3a91952 Whvj26yZchrz2jiVS3IZrwZ2DXX71qu4gynanpV3G4I=
 -- want/gha-preserve.sum --
 version 1
 
 actions/checkout@v4.1.1 this-is-invalid-but-should-not-be-updated
-actions/setup-go@v5.0.0 7lPZupz84sSI3T+PiaMr/ML3XPqJaEo7dMaPsQUnM6c=
-golangci/golangci-lint-action@3a91952 CVRgC7gGqkOiujfm0VMRKppg/Ztv8FW9GYmyJzcwlCI=
+actions/composite@v1 a3ht0IImDEBC7NqbohfejBtv7W5GdKiGJgc4OtYkjEs=
+actions/setup-go@v5.0.0 NoW6+RttcHeApXsFxN2DfY/2Oc7t0g9mgq22uJ3rAbg=
+actions/setup-node@v4.4.0 Gdoys4h+gIN02lzrWZW0uxjBQ8Rk5YSE6+q1SOrw/+o=
+golangci/golangci-lint-action@3a91952 Whvj26yZchrz2jiVS3IZrwZ2DXX71qu4gynanpV3G4I=
 -- unchanged/.github/workflows/gha.sum --
 version 1
 
-actions/checkout@v4.1.1 KsR9XQGH7ydTl01vlD8pIZrXhkzXyjcnzhmP+/KaJZI=
-actions/setup-go@v5.0.0 7lPZupz84sSI3T+PiaMr/ML3XPqJaEo7dMaPsQUnM6c=
-golangci/golangci-lint-action@3a91952 CVRgC7gGqkOiujfm0VMRKppg/Ztv8FW9GYmyJzcwlCI=
+actions/checkout@v4.1.1 TTVf+dWEJueFyMoZnvuqlW5lX4aXYXxGWaFaV8lO910=
+actions/composite@v1 a3ht0IImDEBC7NqbohfejBtv7W5GdKiGJgc4OtYkjEs=
+actions/setup-go@v5.0.0 NoW6+RttcHeApXsFxN2DfY/2Oc7t0g9mgq22uJ3rAbg=
+actions/setup-node@v4.4.0 Gdoys4h+gIN02lzrWZW0uxjBQ8Rk5YSE6+q1SOrw/+o=
+golangci/golangci-lint-action@3a91952 Whvj26yZchrz2jiVS3IZrwZ2DXX71qu4gynanpV3G4I=
 -- unchanged/.github/workflows/workflow.yml --
 name: Example workflow
 on: [push]
@@ -65,6 +71,8 @@ jobs:
         go-version-file: go.mod
     - name: golangci-lint
       uses: golangci/golangci-lint-action@3a91952
+    - name: This step uses transitive actions
+      uses: actions/composite@v1
     - name: This step uses a local action
       uses: ./.github/actions/hello-world-action
     - name: This step uses a Docker Hub action
@@ -74,9 +82,11 @@ jobs:
 -- changed/.github/workflows/gha.sum --
 version 1
 
-actions/checkout@main PKruFKnotZi8RQ196H3R7c5bgw9+mfI7BN/h0A7XiV8=
-actions/setup-go@v5.0.0 7lPZupz84sSI3T+PiaMr/ML3XPqJaEo7dMaPsQUnM6c=
-golangci/golangci-lint-action@3a91952 CVRgC7gGqkOiujfm0VMRKppg/Ztv8FW9GYmyJzcwlCI=
+actions/checkout@main JHipZi1UCvybC3fwi9RFLTK8vpI/gURTga/ColyHI4k=
+actions/composite@v1 a3ht0IImDEBC7NqbohfejBtv7W5GdKiGJgc4OtYkjEs=
+actions/setup-go@v5.0.0 NoW6+RttcHeApXsFxN2DfY/2Oc7t0g9mgq22uJ3rAbg=
+actions/setup-node@v4.3.0 95uwSqDyUuR/AjEP6GwURLEvoyCfPVG72zlrkAMmtw8=
+golangci/golangci-lint-action@3a91952 Whvj26yZchrz2jiVS3IZrwZ2DXX71qu4gynanpV3G4I=
 -- changed/.github/workflows/workflow.yml --
 name: Example workflow
 on: [push]
@@ -94,6 +104,8 @@ jobs:
         go-version-file: go.mod
     - name: golangci-lint
       uses: golangci/golangci-lint-action@3a91952
+    - name: This step uses transitive actions
+      uses: actions/composite@v1
     - name: This step uses a local action
       uses: ./.github/actions/hello-world-action
     - name: This step uses a Docker Hub action
@@ -103,10 +115,13 @@ jobs:
 -- remove/.github/workflows/gha.sum --
 version 1
 
-actions/checkout@main PKruFKnotZi8RQ196H3R7c5bgw9+mfI7BN/h0A7XiV8=
-actions/checkout@v4.1.1 KsR9XQGH7ydTl01vlD8pIZrXhkzXyjcnzhmP+/KaJZI=
-actions/setup-go@v5.0.0 7lPZupz84sSI3T+PiaMr/ML3XPqJaEo7dMaPsQUnM6c=
-golangci/golangci-lint-action@3a91952 CVRgC7gGqkOiujfm0VMRKppg/Ztv8FW9GYmyJzcwlCI=
+actions/checkout@main JHipZi1UCvybC3fwi9RFLTK8vpI/gURTga/ColyHI4k=
+actions/checkout@v4.1.1 TTVf+dWEJueFyMoZnvuqlW5lX4aXYXxGWaFaV8lO910=
+actions/composite@v1 a3ht0IImDEBC7NqbohfejBtv7W5GdKiGJgc4OtYkjEs=
+actions/setup-go@v5.0.0 NoW6+RttcHeApXsFxN2DfY/2Oc7t0g9mgq22uJ3rAbg=
+actions/setup-node@v4.3.0 95uwSqDyUuR/AjEP6GwURLEvoyCfPVG72zlrkAMmtw8=
+actions/setup-node@v4.4.0 Gdoys4h+gIN02lzrWZW0uxjBQ8Rk5YSE6+q1SOrw/+o=
+golangci/golangci-lint-action@3a91952 Whvj26yZchrz2jiVS3IZrwZ2DXX71qu4gynanpV3G4I=
 -- remove/.github/workflows/workflow.yml --
 name: Example workflow
 on: [push]
@@ -124,6 +139,8 @@ jobs:
         go-version-file: go.mod
     - name: golangci-lint
       uses: golangci/golangci-lint-action@3a91952
+    - name: This step uses transitive actions
+      uses: actions/composite@v1
     - name: This step uses a local action
       uses: ./.github/actions/hello-world-action
     - name: This step uses a Docker Hub action
@@ -134,8 +151,10 @@ jobs:
 version 1
 
 actions/checkout@v4.1.1 this-is-invalid-but-should-not-be-updated
+actions/composite@v1 a3ht0IImDEBC7NqbohfejBtv7W5GdKiGJgc4OtYkjEs=
 actions/setup-go@v4.1.0 RQ197c5MRKiujfm0VpQ19p7BN/07XFW9H3R7GH36RXi=
-golangci/golangci-lint-action@3a91952 CVRgC7gGqkOiujfm0VMRKppg/Ztv8FW9GYmyJzcwlCI=
+actions/setup-node@v4.4.0 Gdoys4h+gIN02lzrWZW0uxjBQ8Rk5YSE6+q1SOrw/+o=
+golangci/golangci-lint-action@3a91952 Whvj26yZchrz2jiVS3IZrwZ2DXX71qu4gynanpV3G4I=
 -- preserve/.github/workflows/workflow.yml --
 name: Example workflow
 on: [push]
@@ -153,21 +172,27 @@ jobs:
         go-version-file: go.mod
     - name: golangci-lint
       uses: golangci/golangci-lint-action@3a91952
+    - name: This step uses transitive actions
+      uses: actions/composite@v1
     - name: This step uses a local action
       uses: ./.github/actions/hello-world-action
     - name: This step uses a Docker Hub action
       uses: docker://alpine:3.8
     - name: This step does not use an action
       run: Echo 'hello world!'
--- .cache/actions/checkout/main/.keep --
-This file exist to avoid fetching "actions/checkout@main" and give the Action a
-unique checksum.
--- .cache/actions/checkout/v4.1.1/.keep --
-This file exist to avoid fetching "actions/checkout@v4.1.1" and give the Action
-a unique checksum.
--- .cache/actions/setup-go/v5.0.0/.keep --
-This file exists to avoid fetching "actions/setup-go@v5.0.0" and give the Action
-a unique checksum.
--- .cache/golangci/golangci-lint-action/3a91952/.keep --
-This file exist to avoid fetching "golangci/golangci-lint-action@3a91952" and
-give the Action a unique checksum.
+-- .cache/actions/checkout/v4.1.1/action.yml --
+name: actions/checkout@v4.1.1
+-- .cache/actions/composite/v1/action.yml --
+name: actions/composite@v1
+runs:
+  steps:
+  - name: Also a direct dependency
+    uses: actions/setup-go@v5.0.0
+  - name: Unique transitive dependency
+    uses: actions/setup-node@v4.4.0
+-- .cache/actions/setup-go/v5.0.0/action.yml --
+name: actions/setup-go@v5.0.0
+-- .cache/actions/setup-node/v4.4.0/action.yml --
+name: actions/setup-node@v4.4.0
+-- .cache/golangci/golangci-lint-action/3a91952/action.yml --
+name: golangci/golangci-lint-action@3a91952

--- a/testdata/update/success.txtar
+++ b/testdata/update/success.txtar
@@ -30,6 +30,14 @@ stdout 'Ok'
 ! stderr .
 cmp preserve/.github/workflows/gha.sum want/gha-preserve.sum
 
+# Remove transitive
+cmp changed/.github/workflows/gha.sum want/gha.sum
+
+exec ghasum update -cache .cache/ -no-transitive changed/
+stdout 'Ok'
+! stderr .
+cmp changed/.github/workflows/gha.sum want/gha-no-transitive.sum
+
 -- want/gha.sum --
 version 1
 
@@ -37,6 +45,13 @@ actions/checkout@v4.1.1 TTVf+dWEJueFyMoZnvuqlW5lX4aXYXxGWaFaV8lO910=
 actions/composite@v1 a3ht0IImDEBC7NqbohfejBtv7W5GdKiGJgc4OtYkjEs=
 actions/setup-go@v5.0.0 NoW6+RttcHeApXsFxN2DfY/2Oc7t0g9mgq22uJ3rAbg=
 actions/setup-node@v4.4.0 Gdoys4h+gIN02lzrWZW0uxjBQ8Rk5YSE6+q1SOrw/+o=
+golangci/golangci-lint-action@3a91952 Whvj26yZchrz2jiVS3IZrwZ2DXX71qu4gynanpV3G4I=
+-- want/gha-no-transitive.sum --
+version 1
+
+actions/checkout@v4.1.1 TTVf+dWEJueFyMoZnvuqlW5lX4aXYXxGWaFaV8lO910=
+actions/composite@v1 a3ht0IImDEBC7NqbohfejBtv7W5GdKiGJgc4OtYkjEs=
+actions/setup-go@v5.0.0 NoW6+RttcHeApXsFxN2DfY/2Oc7t0g9mgq22uJ3rAbg=
 golangci/golangci-lint-action@3a91952 Whvj26yZchrz2jiVS3IZrwZ2DXX71qu4gynanpV3G4I=
 -- want/gha-preserve.sum --
 version 1

--- a/testdata/verify/error.txtar
+++ b/testdata/verify/error.txtar
@@ -44,6 +44,12 @@ stderr 'an unexpected error occurred'
 stderr 'could not parse workflow'
 stderr '.github/workflows/workflow.yml'
 
+# Invalid manifest
+! exec ghasum verify -cache .cache/ invalid-manifest/
+! stdout 'Ok'
+stderr 'an unexpected error occurred'
+stderr 'could not parse manifest'
+
 # Directory not found
 ! exec ghasum verify directory-not-found/
 ! stdout 'Ok'
@@ -83,6 +89,22 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
+-- invalid-manifest/.github/workflows/gha.sum --
+version 1
+
+actions/composite@v1 sD5wRDv4rn1UBi0Mzs9jHAB++jiJuAVuggdh437FKHE=
+actions/setup-go@v5 Vi4XogAGoojozgoXrRN/OBL93QIcbsxLJEOOAwlx+e8=
+-- invalid-manifest/.github/workflows/workflow.yml --
+name: Faulty workflow
+on: [push]
+
+jobs:
+  example:
+    name: example
+    runs-on: ubuntu-24.04
+    steps:
+    - name: This step uses transitive actions
+      uses: actions/composite@v1
 -- invalid-workflow/.github/workflows/gha.sum --
 version 1
 
@@ -148,3 +170,11 @@ jobs:
         go-version-file: go.mod
     - name: This step does not use an action
       run: Echo 'hello world!'
+-- .cache/actions/composite/v1/action.yml --
+name: actions/composite@v1
+runs:
+  steps:
+- name: Also a direct dependency
+  uses: actions/setup-go@v5
+-- .cache/actions/setup-go/v5/action.yml --
+name: actions/setup-go@v5

--- a/testdata/verify/problems.txtar
+++ b/testdata/verify/problems.txtar
@@ -16,6 +16,12 @@ stdout .
 ! stdout 'Ok'
 ! stderr .
 
+# Checksum mismatch - Transitive
+! exec ghasum verify -cache .cache/ mismatch/.github/workflows/workflow.yml:transitive
+stdout .
+! stdout 'Ok'
+! stderr .
+
 # Checksum missing - Repo
 ! exec ghasum verify -cache .cache/ missing/
 stdout .
@@ -34,11 +40,18 @@ stdout .
 ! stdout 'Ok'
 ! stderr .
 
+# Checksum missing - Transitive
+! exec ghasum verify -cache .cache/ missing/.github/workflows/workflow.yml:transitive
+stdout .
+! stdout 'Ok'
+! stderr .
+
 -- mismatch/.github/workflows/gha.sum --
 version 1
 
 actions/checkout@v4 oJp2lqI5zRjHTtu2vQ9/rfcqiYqRAnhqMjwnw/ss4x0=
-actions/setup-go@v5 /ChzMZC1jsCd/aTotskAS7hl1cX9/M5XsV7mJHCMuME=
+actions/composite@v1 VHsmCNCNfU2qFyTntn14sMoZL1UOOyne/omuQUvzQfA=
+actions/setup-go@v5 this-is-intentionally-invalid
 -- mismatch/.github/workflows/workflow.yml --
 name: Example workflow
 on: [push]
@@ -56,10 +69,17 @@ jobs:
         go-version-file: go.mod
     - name: This step does not use an action
       run: Echo 'hello world!'
+  transitive:
+    name: example
+    runs-on: ubuntu-24.04
+    steps:
+    - name: This step uses transitive actions
+      uses: actions/composite@v1
 -- missing/.github/workflows/gha.sum --
 version 1
 
 actions/checkout@v4 oJp2lqI5zRjHTtu2vQ9/rfcqiYqRAnhqMjwnw/ss4x0=
+actions/composite@v1 VHsmCNCNfU2qFyTntn14sMoZL1UOOyne/omuQUvzQfA=
 -- missing/.github/workflows/workflow.yml --
 name: Example workflow
 on: [push]
@@ -77,9 +97,18 @@ jobs:
         go-version-file: go.mod
     - name: This step does not use an action
       run: Echo 'hello world!'
--- .cache/actions/checkout/v4/.keep --
-This file exist to avoid fetching "actions/checkout@v4" and give the Action a
-unique checksum.
--- .cache/actions/setup-go/v5/.keep --
-This file exists to avoid fetching "actions/setup-go@v5" and give the Action a
-unique checksum.
+  transitive:
+    name: example
+    runs-on: ubuntu-24.04
+    steps:
+    - name: This step uses transitive actions
+      uses: actions/composite@v1
+-- .cache/actions/checkout/v4/action.yml --
+name: actions/checkout@v4
+-- .cache/actions/composite/v1/action.yml --
+name: actions/composite@v1
+runs:
+  steps:
+  - uses: actions/setup-go@v5
+-- .cache/actions/setup-go/v5/action.yml --
+name: actions/setup-go@v5

--- a/testdata/verify/success.txtar
+++ b/testdata/verify/success.txtar
@@ -46,9 +46,11 @@ stdout 'Ok'
 -- up-to-date/.github/workflows/gha.sum --
 version 1
 
-actions/checkout@main PKruFKnotZi8RQ196H3R7c5bgw9+mfI7BN/h0A7XiV8=
-actions/setup-go@v5.0.0 7lPZupz84sSI3T+PiaMr/ML3XPqJaEo7dMaPsQUnM6c=
-golangci/golangci-lint-action@3a91952 CVRgC7gGqkOiujfm0VMRKppg/Ztv8FW9GYmyJzcwlCI=
+actions/checkout@main JHipZi1UCvybC3fwi9RFLTK8vpI/gURTga/ColyHI4k=
+actions/composite@v1 a3ht0IImDEBC7NqbohfejBtv7W5GdKiGJgc4OtYkjEs=
+actions/setup-go@v5.0.0 NoW6+RttcHeApXsFxN2DfY/2Oc7t0g9mgq22uJ3rAbg=
+actions/setup-node@v4.4.0 Gdoys4h+gIN02lzrWZW0uxjBQ8Rk5YSE6+q1SOrw/+o=
+golangci/golangci-lint-action@3a91952 Whvj26yZchrz2jiVS3IZrwZ2DXX71qu4gynanpV3G4I=
 -- up-to-date/.github/workflows/workflow.yml --
 name: Example workflow
 on: [push]
@@ -66,6 +68,8 @@ jobs:
         go-version-file: go.mod
     - name: golangci-lint
       uses: golangci/golangci-lint-action@3a91952
+    - name: This step uses transitive actions
+      uses: actions/composite@v1
     - name: This step uses a local action
       uses: ./.github/actions/hello-world-action
     - name: This step uses a Docker Hub action
@@ -75,8 +79,10 @@ jobs:
 -- redundant/.github/workflows/gha.sum --
 version 1
 
-actions/checkout@main PKruFKnotZi8RQ196H3R7c5bgw9+mfI7BN/h0A7XiV8=
-actions/setup-go@v5.0.0 7lPZupz84sSI3T+PiaMr/ML3XPqJaEo7dMaPsQUnM6c=
+actions/checkout@main JHipZi1UCvybC3fwi9RFLTK8vpI/gURTga/ColyHI4k=
+actions/composite@v1 a3ht0IImDEBC7NqbohfejBtv7W5GdKiGJgc4OtYkjEs=
+actions/setup-go@v5.0.0 NoW6+RttcHeApXsFxN2DfY/2Oc7t0g9mgq22uJ3rAbg=
+actions/setup-node@v4.4.0 Gdoys4h+gIN02lzrWZW0uxjBQ8Rk5YSE6+q1SOrw/+o=
 golangci/golangci-lint-action@3a91952 this-action-is-not-used-in-the-repo
 -- redundant/.github/workflows/workflow.yml --
 name: Example workflow
@@ -93,6 +99,8 @@ jobs:
       uses: actions/setup-go@v5.0.0
       with:
         go-version-file: go.mod
+    - name: This step uses transitive actions
+      uses: actions/composite@v1
     - name: This step uses a local action
       uses: ./.github/actions/hello-world-action
     - name: This step uses a Docker Hub action
@@ -102,8 +110,10 @@ jobs:
 -- partial/.github/workflows/gha.sum --
 version 1
 
-actions/checkout@main PKruFKnotZi8RQ196H3R7c5bgw9+mfI7BN/h0A7XiV8=
-actions/setup-go@v5.0.0 7lPZupz84sSI3T+PiaMr/ML3XPqJaEo7dMaPsQUnM7c=
+actions/checkout@main JHipZi1UCvybC3fwi9RFLTK8vpI/gURTga/ColyHI4k=
+actions/composite@v1 a3ht0IImDEBC7NqbohfejBtv7W5GdKiGJgc4OtYkjEs=
+actions/setup-go@v5.0.0 this-is-intentionally-invalid
+actions/setup-node@v4.4.0 Gdoys4h+gIN02lzrWZW0uxjBQ8Rk5YSE6+q1SOrw/+o=
 -- partial/.github/workflows/valid.yml --
 name: Example workflow
 on: [push]
@@ -140,12 +150,21 @@ jobs:
       uses: actions/setup-go@v5.0.0
       with:
         go-version-file: go.mod
--- .cache/actions/checkout/main/.keep --
-This file exist to avoid fetching "actions/checkout@main" and give the Action a
-unique checksum.
--- .cache/actions/setup-go/v5.0.0/.keep --
-This file exists to avoid fetching "actions/setup-go@v5.0.0" and give the Action
-a unique checksum.
--- .cache/golangci/golangci-lint-action/3a91952/.keep --
-This file exist to avoid fetching "golangci/golangci-lint-action@3a91952" and
-give the Action a unique checksum.
+    - name: This step uses transitive actions
+      uses: actions/composite@v1
+-- .cache/actions/checkout/main/action.yml --
+name: actions/checkout@main
+-- .cache/actions/composite/v1/action.yml --
+name: actions/composite@v1
+runs:
+  steps:
+  - name: Also a direct dependency
+    uses: actions/setup-go@v5.0.0
+  - name: Unique transitive dependency
+    uses: actions/setup-node@v4.4.0
+-- .cache/actions/setup-go/v5.0.0/action.yml --
+name: actions/setup-go@v5.0.0
+-- .cache/actions/setup-node/v4.4.0/action.yml --
+name: actions/setup-node@v4.4.0
+-- .cache/golangci/golangci-lint-action/3a91952/action.yml --
+name: golangci/golangci-lint-action@3a91952

--- a/testdata/verify/success.txtar
+++ b/testdata/verify/success.txtar
@@ -28,6 +28,11 @@ exec ghasum verify -cache .cache/ redundant/.github/workflows/workflow.yml:examp
 stdout 'Ok'
 ! stderr .
 
+# Redundant checksum stored - Transitive
+exec ghasum verify -cache .cache/ -no-transitive no-transitive/
+stdout 'Ok'
+! stderr .
+
 # Checksums match partially - Workflow
 exec ghasum verify -cache .cache/ partial/.github/workflows/valid.yml
 stdout 'Ok'
@@ -152,6 +157,29 @@ jobs:
         go-version-file: go.mod
     - name: This step uses transitive actions
       uses: actions/composite@v1
+-- no-transitive/.github/workflows/gha.sum --
+version 1
+
+actions/composite@v1 a3ht0IImDEBC7NqbohfejBtv7W5GdKiGJgc4OtYkjEs=
+actions/setup-go@v5.0.0 NoW6+RttcHeApXsFxN2DfY/2Oc7t0g9mgq22uJ3rAbg=
+actions/setup-node@v4.4.0 this-action-is-only-used-transitively
+-- no-transitive/.github/workflows/workflow.yml --
+name: Example workflow
+on: [push]
+
+jobs:
+  example:
+    name: example
+    runs-on: ubuntu-22.04
+    steps:
+    - name: Install Go
+      uses: actions/setup-go@v5.0.0
+      with:
+        go-version-file: go.mod
+    - name: This step uses transitive actions
+      uses: actions/composite@v1
+    - name: This step does not use an action
+      run: Echo 'hello world!'
 -- .cache/actions/checkout/main/action.yml --
 name: actions/checkout@main
 -- .cache/actions/composite/v1/action.yml --


### PR DESCRIPTION
Closes #49 

## Summary

Add support for recording and verifying checksums for transitive dependencies on actions, i.e. actions used by [composite actions](https://docs.github.com/en/actions/sharing-automations/creating-actions/creating-a-composite-action) (recursively).