### PR TITLE
Replace `os.DirFS` with `os.OpenRoot`

### DIFF
--- a/cmd/ghasum/init.go
+++ b/cmd/ghasum/init.go
@@ -51,8 +51,13 @@ func cmdInit(argv []string) error {
 		return errors.Join(errCache, err)
 	}
 
+	repo, err := os.OpenRoot(target)
+	if err != nil {
+		return errors.Join(errUnexpected, err)
+	}
+
 	cfg := ghasum.Config{
-		Repo:  os.DirFS(target),
+		Repo:  repo.FS(),
 		Path:  target,
 		Cache: c,
 	}

--- a/cmd/ghasum/update.go
+++ b/cmd/ghasum/update.go
@@ -48,23 +48,24 @@ func cmdUpdate(argv []string) error {
 		return err
 	}
 
-	if _, err = os.Stat(target); err != nil {
-		return errors.Join(errUnexpected, err)
-	}
-
 	c, err := cache.New(*flagCache, *flagNoCache)
 	if err != nil {
 		return errors.Join(errCache, err)
 	}
 
 	if !*flagNoEvict {
-		if err := c.Evict(); err != nil {
-			return errors.Join(errUnexpected, err)
+		if err = c.Evict(); err != nil {
+			return errors.Join(errCache, err)
 		}
 	}
 
+	repo, err := os.OpenRoot(target)
+	if err != nil {
+		return errors.Join(errUnexpected, err)
+	}
+
 	cfg := ghasum.Config{
-		Repo:  os.DirFS(target),
+		Repo:  repo.FS(),
 		Path:  target,
 		Cache: c,
 	}

--- a/cmd/ghasum/verify.go
+++ b/cmd/ghasum/verify.go
@@ -75,13 +75,18 @@ func cmdVerify(argv []string) error {
 	}
 
 	if !*flagNoEvict {
-		if evictErr := c.Evict(); evictErr != nil {
-			return errors.Join(errUnexpected, evictErr)
+		if err = c.Evict(); err != nil {
+			return errors.Join(errCache, err)
 		}
 	}
 
+	repo, err := os.OpenRoot(target)
+	if err != nil {
+		return errors.Join(errUnexpected, err)
+	}
+
 	cfg := ghasum.Config{
-		Repo:     os.DirFS(target),
+		Repo:     repo.FS(),
 		Path:     target,
 		Workflow: workflow,
 		Job:      job,

--- a/testdata/update/error.txtar
+++ b/testdata/update/error.txtar
@@ -11,27 +11,27 @@ stderr 'an unexpected error occurred'
 stderr 'ghasum has not yet been initialized'
 
 # Sumfile with syntax error in headers
-! exec ghasum verify sumfile-syntax-headers/
+! exec ghasum update sumfile-syntax-headers/
 ! stdout 'Ok'
 stderr 'an unexpected error occurred'
 stderr 'sumfile headers are invalid'
 stderr 'invalid header on line 2'
 
 # Sumfile with syntax error in entries
-! exec ghasum verify sumfile-syntax-entries/
+! exec ghasum update sumfile-syntax-entries/
 ! stdout 'Ok'
 stderr 'an unexpected error occurred'
 stderr 'syntax error on line 3'
 
 # Sumfile with duplicate headers
-! exec ghasum verify sumfile-duplicate-headers/
+! exec ghasum update sumfile-duplicate-headers/
 ! stdout 'Ok'
 stderr 'an unexpected error occurred'
 stderr 'sumfile headers are invalid'
 stderr 'duplicate header "foo" on line 3'
 
 # Sumfile with duplicate entries
-! exec ghasum verify sumfile-duplicate-entries/
+! exec ghasum update sumfile-duplicate-entries/
 ! stdout 'Ok'
 stderr 'an unexpected error occurred'
 stderr 'checksums are corrupted'


### PR DESCRIPTION
Closes #210

## Summary

Replace usage of `os.DirFS` by `os.OpenRoot` followed by getting an `fs.FS` instance as `root.FS()`. This is added as a hardening measure, preventing the code that uses this `fs.FS` from doing anything* outside the root.

The * here is that, unfortunately, only `fs.StatFS`, `fs.ReadFileFs`, and `fs.ReadDirFS` are implemented while `ghasum` also has to write to file, which necessarily has to be done with APIs that could reach outside the root's boundaries.