### PR TITLE
Enable cache eviction on `ghasum init`

### DIFF
--- a/cmd/ghasum/init.go
+++ b/cmd/ghasum/init.go
@@ -29,6 +29,7 @@ func cmdInit(argv []string) error {
 		flags            = flag.NewFlagSet(cmdNameInit, flag.ContinueOnError)
 		flagCache        = flags.String(flagNameCache, "", "")
 		flagNoCache      = flags.Bool(flagNameNoCache, false, "")
+		flagNoEvict      = flags.Bool(flagNameNoEvict, false, "")
 		flagNoTransitive = flags.Bool(flagNameNoTransitive, false, "")
 	)
 
@@ -50,6 +51,12 @@ func cmdInit(argv []string) error {
 	c, err := cache.New(*flagCache, *flagNoCache)
 	if err != nil {
 		return errors.Join(errCache, err)
+	}
+
+	if !*flagNoEvict {
+		if err = c.Evict(); err != nil {
+			return errors.Join(errCache, err)
+		}
 	}
 
 	repo, err := os.OpenRoot(target)
@@ -87,6 +94,8 @@ The available flags are:
         Defaults to a directory named .ghasum in the user's home directory.
     -no-cache
         Disable the use of the cache. Makes the -cache flag ineffective.
+    -no-evict
+        Disable cache eviction.
     -no-transitive
         Do not compute checksums for transitive actions.`
 }


### PR DESCRIPTION
Relates to #54

## Summary

Update the `ghasum init` command to include cache eviction, just like `ghasum update` and `ghasum verify`. The motivation for this is that, like the other two commands, this commands behavior depends on the state of the cache and so should have the same eviction behavior (for the same reason it now supports the `-no-evict` option.