### PR TITLE
Refactor implementation for help texts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,10 @@ Versioning].
 
 ## [Unreleased]
 
-- _No changes yet_
+### Enhancements
+
+- Correct typo in the `ghasum help verify` output.
+- Enable cache eviction on `ghasum init`.
 
 ## [v0.4.0] - 2025-04-27
 

--- a/cmd/ghasum/cache.go
+++ b/cmd/ghasum/cache.go
@@ -84,5 +84,6 @@ The available flags are:
 
     -cache dir
         The location of the cache directory. Defaults to a directory named
-        .ghasum/ in the user's home directory.`
+        .ghasum/ in the user's home directory.
+`
 }

--- a/cmd/ghasum/help.go
+++ b/cmd/ghasum/help.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Eric Cornelissen
+// Copyright 2024-2025 Eric Cornelissen
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,18 +18,21 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"os"
 )
 
 func cmdHelp(argv []string) error {
-	flagsHelp := flag.NewFlagSet(cmdNameHelp, flag.ContinueOnError)
-	if err := flagsHelp.Parse(argv); err != nil {
+	flags := flag.NewFlagSet(cmdNameHelp, flag.ContinueOnError)
+
+	flags.Usage = func() { fmt.Fprintln(os.Stderr) }
+	if err := flags.Parse(argv); err != nil {
 		return errUsage
 	}
 
-	args := flagsHelp.Args()
+	args := flags.Args()
 	switch len(args) {
 	case 0:
-		fmt.Println(help())
+		fmt.Print(help())
 		return nil
 	case 1:
 		return helpFor(args[0])
@@ -44,7 +47,7 @@ func helpFor(command string) error {
 		return fmt.Errorf(`unknown command %q (see "ghasum help")`, command)
 	}
 
-	fmt.Println(fn())
+	fmt.Print(fn())
 	return nil
 }
 
@@ -62,5 +65,6 @@ The available commands are:
     verify    Verify the checksums for a repository.
     version   Print the ghasum version.
 
-Use "ghasum help <command>" for more information about a command.`
+Use "ghasum help <command>" for more information about a command.
+`
 }

--- a/cmd/ghasum/init.go
+++ b/cmd/ghasum/init.go
@@ -97,5 +97,6 @@ The available flags are:
     -no-evict
         Disable cache eviction.
     -no-transitive
-        Do not compute checksums for transitive actions.`
+        Do not compute checksums for transitive actions.
+`
 }

--- a/cmd/ghasum/main.go
+++ b/cmd/ghasum/main.go
@@ -84,14 +84,14 @@ func main() {
 
 func run() int {
 	if len(os.Args) < 2 {
-		fmt.Println(help())
+		fmt.Print(help())
 		return exitCodeSuccess
 	}
 
 	command := os.Args[1]
 	fn, ok := commands[command]
 	if !ok {
-		fmt.Println(help())
+		fmt.Print(help())
 		return exitCodeUsage
 	}
 
@@ -101,7 +101,7 @@ func run() int {
 		return exitCodeSuccess
 	case errors.Is(err, errUsage):
 		helpFn := helpers[command]
-		fmt.Println(helpFn())
+		fmt.Print(helpFn())
 		return exitCodeUsage
 	case errors.Is(err, errFailure):
 		fmt.Println(err)

--- a/cmd/ghasum/main_test.go
+++ b/cmd/ghasum/main_test.go
@@ -94,8 +94,8 @@ func TestHelpers(t *testing.T) {
 				t.Errorf("Help is missing substring %q", want)
 			}
 
-			if strings.TrimSpace(got) != got {
-				t.Errorf("Help should not have leading nor trailing whitespace")
+			if !strings.HasSuffix(got, "\n") {
+				t.Errorf("Help should end with a trailing newline")
 			}
 
 			if strings.Contains(got, "<command>") {

--- a/cmd/ghasum/update.go
+++ b/cmd/ghasum/update.go
@@ -102,5 +102,6 @@ The available flags are:
     -no-evict
         Disable cache eviction.
     -no-transitive
-        Do not compute checksums for transitive actions.`
+        Do not compute checksums for transitive actions.
+`
 }

--- a/cmd/ghasum/verify.go
+++ b/cmd/ghasum/verify.go
@@ -155,5 +155,6 @@ The available flags are:
         Run without fetching repositories from the internet, verify exclusively
         against the cache. If the cache is missing an entry it causes an error.
     -no-transitive
-        Do not compute checksums for transitive actions.`
+        Do not verify checksums for transitive actions.
+`
 }

--- a/cmd/ghasum/version.go
+++ b/cmd/ghasum/version.go
@@ -48,5 +48,6 @@ func cmdVersion(argv []string) error {
 func helpVersion() string {
 	return `usage: ghasum version
 
-Prints the version of ghasum.`
+Prints the version of ghasum.
+`
 }


### PR DESCRIPTION
## Summary

This changes the static help text messages to include a newline and print them without a newline. The motivation for this is that it simplifies the diff if text is appended to static help text.

Additionally this removes a redundant "Usage of help:" message when the `ghasum help` command is used incorrectly.