### PR TITLE
Handle `Dockerfile` action manifest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ Versioning].
 
 ## [Unreleased]
 
+### Bugs
+
+- Fix errors for actions with a `Dockerfile` manifest.
+
+## [v0.5.0] - 2025-05-03
+
 ### Enhancements
 
 - Correct typo in the `ghasum help verify` output.

--- a/README.md
+++ b/README.md
@@ -59,12 +59,15 @@ recommended to use commit SHAs instead to avoid failing verification by ghasum.
 
 - Requires manual intervention when an Action is updated.
 - The hashing algorithm used for checksums is not configurable.
-- Checksums do not provide protection against [unpinnable actions].[^1] 
+- `ghasum` does not (yet, [#216]) handle Docker-based [unpinnable actions].
+- Checksums do not provide protection against code-based [unpinnable actions].
 
-[^1]: See [github/roadmap#592] for work on unpinnable actions by GitHub.
+Some of these limitations may be addressed by Github's Immutable Actions
+initiative, see [github/roadmap#592] for more information.
 
-[unpinnable actions]: https://www.paloaltonetworks.com/blog/prisma-cloud/unpinnable-actions-github-security/
+[#216]: https://github.com/chains-project/ghasum/issues/216
 [github/roadmap#592]: https://github.com/github/roadmap/issues/592
+[unpinnable actions]: https://www.paloaltonetworks.com/blog/prisma-cloud/unpinnable-actions-github-security/
 
 ## Background
 

--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -203,8 +203,7 @@ version 1
 
 ## Definitions
 
-- _action manifest_ is the file `action.yml` or `action.yaml` (mutually
-  exclusive).
+- _action manifest_ is the file `action.yml`, `action.yaml`, or `Dockerfile`.
 - _checksum file_ is the file `.github/workflows/gha.sum`.
 - _workflows directory_ is the directory `.github/workflows`.
 

--- a/internal/gha/errors.go
+++ b/internal/gha/errors.go
@@ -22,4 +22,7 @@ var (
 	ErrInvalidUsesRepo = errors.New("invalid repository in uses")
 	ErrInvalidUsesPath = errors.New("invalid repository path in uses")
 	ErrLocalAction     = errors.New("uses is a local action")
+
+	ErrDockerfileManifest = errors.New("found a Dockerfile manifest")
+	ErrNoManifest         = errors.New("could not find a manifest")
 )

--- a/internal/gha/gha.go
+++ b/internal/gha/gha.go
@@ -15,6 +15,7 @@
 package gha
 
 import (
+	"errors"
 	"fmt"
 	"io/fs"
 	"path/filepath"
@@ -147,7 +148,9 @@ func JobActions(repo fs.FS, path, name string) ([]GitHubAction, error) {
 // specified directory in the given file system hierarchy.
 func ManifestActions(repo fs.FS, path string) ([]GitHubAction, error) {
 	data, err := manifestInRepo(repo, path)
-	if err != nil {
+	if errors.Is(err, ErrDockerfileManifest) {
+		return nil, nil
+	} else if err != nil {
 		return nil, err
 	}
 

--- a/internal/gha/gha_test.go
+++ b/internal/gha/gha_test.go
@@ -667,8 +667,8 @@ func TestManifestActions(t *testing.T) {
 		wantErr bool
 	}
 
-	testCases := []TestCase{
-		{
+	testCases := map[string]TestCase{
+		"root manifest without transitive actions": {
 			fs: map[string]mockFsEntry{
 				"action.yml": {
 					Content: []byte(manifestWithNoSteps),
@@ -677,7 +677,7 @@ func TestManifestActions(t *testing.T) {
 			path:    "",
 			wantErr: false,
 		},
-		{
+		"root manifest with transitive actions": {
 			fs: map[string]mockFsEntry{
 				"action.yml": {
 					Content: []byte(manifestWithStep),
@@ -686,7 +686,7 @@ func TestManifestActions(t *testing.T) {
 			path:    "",
 			wantErr: false,
 		},
-		{
+		"root manifest using nested actions": {
 			fs: map[string]mockFsEntry{
 				"action.yml": {
 					Content: []byte(manifestWithNestedActions),
@@ -695,7 +695,7 @@ func TestManifestActions(t *testing.T) {
 			path:    "",
 			wantErr: false,
 		},
-		{
+		"nested .yml manifest": {
 			fs: map[string]mockFsEntry{
 				"nested": {
 					Dir: true,
@@ -709,7 +709,7 @@ func TestManifestActions(t *testing.T) {
 			path:    "nested",
 			wantErr: false,
 		},
-		{
+		"root .yaml manifest": {
 			fs: map[string]mockFsEntry{
 				"action.yaml": {
 					Content: []byte(manifestWithStep),
@@ -718,7 +718,7 @@ func TestManifestActions(t *testing.T) {
 			path:    "",
 			wantErr: false,
 		},
-		{
+		"nested .yaml manifest": {
 			fs: map[string]mockFsEntry{
 				"nested": {
 					Dir: true,
@@ -732,7 +732,30 @@ func TestManifestActions(t *testing.T) {
 			path:    "nested",
 			wantErr: false,
 		},
-		{
+		"root Dockerfile manifest": {
+			fs: map[string]mockFsEntry{
+				"Dockerfile": {
+					Content: []byte(manifestDockerfile),
+				},
+			},
+			path:    "",
+			wantErr: false,
+		},
+		"nested Dockerfile manifest": {
+			fs: map[string]mockFsEntry{
+				"nested": {
+					Dir: true,
+					Children: map[string]mockFsEntry{
+						"Dockerfile": {
+							Content: []byte(manifestDockerfile),
+						},
+					},
+				},
+			},
+			path:    "nested",
+			wantErr: false,
+		},
+		"manifest with syntax error": {
 			fs: map[string]mockFsEntry{
 				"action.yml": {
 					Content: []byte(yamlWithSyntaxError),
@@ -741,7 +764,7 @@ func TestManifestActions(t *testing.T) {
 			path:    "",
 			wantErr: true,
 		},
-		{
+		"manifest with invalid uses value": {
 			fs: map[string]mockFsEntry{
 				"action.yml": {
 					Content: []byte(manifestWithInvalidUses),
@@ -750,15 +773,15 @@ func TestManifestActions(t *testing.T) {
 			path:    "",
 			wantErr: true,
 		},
-		{
+		"empty repo": {
 			fs:      map[string]mockFsEntry{},
 			path:    "",
 			wantErr: true,
 		},
 	}
 
-	for i, tt := range testCases {
-		t.Run(fmt.Sprintf("#%d", i), func(t *testing.T) {
+	for name, tt := range testCases {
+		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
 			repo, err := mockRepo(tt.fs)

--- a/internal/gha/shared_test.go
+++ b/internal/gha/shared_test.go
@@ -52,6 +52,9 @@ runs:
   steps:
     - uses: this-is-not-an-action
 `
+	manifestDockerfile = `FROM docker.io/alpine:3.21.3
+ENTRYPOINT ["echo", "Hello world!"]
+`
 
 	workflowWithNoJobs = `name: workflow with no jobs
 `


### PR DESCRIPTION
Relates to #223

## Summary

Avoid erroring when an action used by a project has a `Dockerfile` manifest.