### PR TITLE
Add tests for manifest confusion scenario

### DIFF
--- a/internal/gha/actions_test.go
+++ b/internal/gha/actions_test.go
@@ -674,6 +674,18 @@ func TestManifestInRepo(t *testing.T) {
 				dir:  "nested",
 				want: []byte(manifestWithStep),
 			},
+			".yml and .yaml": {
+				fs: map[string]mockFsEntry{
+					"action.yaml": {
+						Content: []byte(yamlWithSyntaxError),
+					},
+					"action.yml": {
+						Content: []byte(manifestWithStep),
+					},
+				},
+				dir:  "",
+				want: []byte(manifestWithStep),
+			},
 		}
 
 		for name, tt := range testCases {

--- a/internal/gha/gha_test.go
+++ b/internal/gha/gha_test.go
@@ -778,6 +778,19 @@ func TestManifestActions(t *testing.T) {
 			path:    "",
 			wantErr: true,
 		},
+		"action.yml takes precedence over action.yaml": {
+			fs: map[string]mockFsEntry{
+				"action.yaml": {
+					Content: []byte(yamlWithSyntaxError),
+				},
+
+				"action.yml": {
+					Content: []byte(manifestWithNoSteps),
+				},
+			},
+			path:    "",
+			wantErr: false,
+		},
 	}
 
 	for name, tt := range testCases {


### PR DESCRIPTION
Closes #223

## Summary

Extend the test suite with tests for manifest confusion, an potential attack vector as described in <https://github.com/ericcornelissen/actions-manifest-confusion>.

These tests ensure that the same manifest that would be used by GitHub Action is parsed for transitive actions, avoiding a scenario where checksums are checked for the wrong set of actions because we considered a different manifest from the GitHub Actions runner.