### PR TITLE
Continuously test `ghasum` on different runners

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -30,8 +30,18 @@ jobs:
     - name: Build binary
       run: go run tasks.go build
   dogfeed:
-    name: Dogfeed
-    runs-on: ubuntu-24.04
+    name: Dogfeed (${{ matrix.name }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        - name: macOS
+          os: macos-15
+        - name: Ubuntu
+          os: ubuntu-24.04
+        - name: Windows
+          os: windows-2025
     needs:
     - test
     steps:
@@ -44,14 +54,32 @@ jobs:
       with:
         go-version-file: go.mod
     - name: Verify action checksums
+      if: matrix.name == 'macOS'
+      env:
+        JOB: ${{ github.job }}
+        WORKFLOW: ${{ github.workflow_ref }}
+      run: |
+        WORKFLOW=$(echo "$WORKFLOW" | cut -d '@' -f 1 | cut -d '/' -f 3-5)
+        go run ./cmd/ghasum verify -cache /Users/runner/work/_actions -no-evict -offline "${WORKFLOW}:${JOB}"
+    - name: Verify action checksums
+      if: matrix.name == 'Ubuntu'
       env:
         JOB: ${{ github.job }}
         WORKFLOW: ${{ github.workflow_ref }}
       run: |
         WORKFLOW=$(echo "$WORKFLOW" | cut -d '@' -f 1 | cut -d '/' -f 3-5)
         go run ./cmd/ghasum verify -cache /home/runner/work/_actions -no-evict -offline "$WORKFLOW:$JOB"
+    - name: Verify action checksums
+      if: matrix.name == 'Windows'
+      env:
+        JOB: ${{ github.job }}
+        WORKFLOW: ${{ github.workflow_ref }}
+      run: |
+        $WorkflowParts = $env:WORKFLOW -split '@'
+        $WorkflowPath = ($WorkflowParts[0] -split '/')[2..4] -join '/'
+        go run ./cmd/ghasum verify -cache D:\a\_actions -no-evict -offline "${WorkflowPath}:${env:JOB}"
     - name: Uninitialize ghasum
-      run: rm -f .github/workflows/gha.sum
+      run: rm .github/workflows/gha.sum
     - name: Run on this repository
       run: |
         go run ./cmd/ghasum init

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ Versioning].
 
 ## [Unreleased]
 
+### Bugs
+
+- Fix verifying a non-job target identified by the absolute path on Windows.
+- Fix various cases where files or directories could not found on Windows.
+
+## [v0.5.1] - 2025-05-25
+
 ### Enhancements
 
 - Report redundant checksums on verification of an entire repository.

--- a/cmd/ghasum/verify.go
+++ b/cmd/ghasum/verify.go
@@ -53,7 +53,7 @@ func cmdVerify(argv []string) error {
 	}
 
 	var job string
-	if i := strings.LastIndexByte(target, 0x3A); i >= 0 {
+	if i := strings.LastIndexByte(target, 0x3A); i > 1 {
 		job = target[i+1:]
 		target = target[0:i]
 	}
@@ -67,6 +67,7 @@ func cmdVerify(argv []string) error {
 	if !stat.IsDir() {
 		repo := path.Join(path.Dir(target), "..", "..")
 		workflow, _ = filepath.Rel(repo, target)
+		workflow = strings.ReplaceAll(workflow, string(filepath.Separator), "/")
 		target = repo
 	}
 

--- a/internal/gha/actions.go
+++ b/internal/gha/actions.go
@@ -21,7 +21,6 @@ import (
 	"io/fs"
 	"maps"
 	"path"
-	"path/filepath"
 	"slices"
 )
 
@@ -141,20 +140,20 @@ func workflowInRepo(repo fs.FS, path string) ([]byte, error) {
 }
 
 func manifestInRepo(repo fs.FS, dir string) ([]byte, error) {
-	path := filepath.Join(dir, "action.yml")
-	if file, err := repo.Open(path); err == nil {
+	manifest := path.Join(dir, "action.yml")
+	if file, err := repo.Open(manifest); err == nil {
 		data, _ := io.ReadAll(file)
 		return data, nil
 	}
 
-	path = filepath.Join(dir, "action.yaml")
-	if file, err := repo.Open(path); err == nil {
+	manifest = path.Join(dir, "action.yaml")
+	if file, err := repo.Open(manifest); err == nil {
 		data, _ := io.ReadAll(file)
 		return data, nil
 	}
 
-	path = filepath.Join(dir, "Dockerfile")
-	if _, err := repo.Open(path); err == nil {
+	manifest = path.Join(dir, "Dockerfile")
+	if _, err := repo.Open(manifest); err == nil {
 		return nil, ErrDockerfileManifest
 	}
 

--- a/internal/gha/gha.go
+++ b/internal/gha/gha.go
@@ -18,7 +18,7 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
-	"path/filepath"
+	"path"
 )
 
 // A GitHubAction identifies a specific version of a GitHub Action.
@@ -64,7 +64,7 @@ const (
 )
 
 // WorkflowsPath is the relative path to the GitHub Actions workflow directory.
-var WorkflowsPath = filepath.Join(".github", "workflows")
+var WorkflowsPath = path.Join(".github", "workflows")
 
 // RepoActions extracts the GitHub Actions used in the repository at the given
 // file system hierarchy.


### PR DESCRIPTION
Relates to #229

## Summary

This aims to uncover (now) and prevent (in the future) bugs related to platform-specific implementation details as observed while trying to integrate `ghasum` into the `windows-2025` runner.

As the most realistic test, I opted to run the dogfeeding test on each runner as a means to ensuring all runners are supported.