### PR TITLE
Bump Go from 1.24.2 to 1.24.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/chains-project/ghasum
 
-go 1.24.2
+go 1.24.4
 
 require (
 	github.com/go-git/go-git/v5 v5.16.1


### PR DESCRIPTION
Relates to #203, [Audit job #807](https://github.com/chains-project/ghasum/actions/runs/15600717952)

## Summary

Upgrade from Go 1.24.2 to 1.24.4 to receive 3 security-related update for the standard library which affect this codebase according to govulncheck.

The relevant security IDs are `GO-2025-3749`, `GO-2025-3750`, and `GO-2025-3751`.