### PR TITLE
Report actions in archived repositories

### DIFF
--- a/cmd/ghasum/list.go
+++ b/cmd/ghasum/list.go
@@ -31,6 +31,7 @@ func cmdList(argv []string) error {
 		flagNoCache      = flags.Bool(flagNameNoCache, false, "")
 		flagNoEvict      = flags.Bool(flagNameNoEvict, false, "")
 		flagNoTransitive = flags.Bool(flagNameNoTransitive, false, "")
+		flagOffline      = flags.Bool(flagNameOffline, false, "")
 	)
 
 	flags.Usage = func() { fmt.Fprintln(os.Stderr) }
@@ -68,6 +69,7 @@ func cmdList(argv []string) error {
 		Repo:       repo.FS(),
 		Path:       target,
 		Cache:      c,
+		Offline:    *flagOffline,
 		Transitive: !(*flagNoTransitive),
 	}
 
@@ -98,5 +100,8 @@ The available flags are:
         Disable cache eviction.
     -no-transitive
         Do not include transitive actions.
+    -offline
+        Run without fetching repositories or metadata from the internet. If the
+        cache is missing an entry it causes an error.
 `
 }

--- a/internal/ghasum/operations.go
+++ b/internal/ghasum/operations.go
@@ -234,5 +234,5 @@ func List(cfg *Config) (string, error) {
 		return "", err
 	}
 
-	return actions.String(), nil
+	return list(cfg, &actions), nil
 }

--- a/internal/ghasum/tree.go
+++ b/internal/ghasum/tree.go
@@ -15,10 +15,7 @@
 package ghasum
 
 import (
-	"fmt"
 	"iter"
-	"slices"
-	"strings"
 
 	"github.com/chains-project/ghasum/internal/gha"
 )
@@ -50,36 +47,4 @@ func (t *tree) every(f func(gha.GitHubAction) bool) bool {
 	}
 
 	return true
-}
-
-func (t *tree) String() string {
-	var b strings.Builder
-
-	root := t.value == nil
-	if !root {
-		name := fmt.Sprintf("%s (%s)", t.value, t.value.Kind)
-		b.WriteString(name)
-		b.WriteRune('\n')
-	}
-
-	ordered := make([]string, len(t.children))
-	mapped := make(map[string]*tree, len(t.children))
-	for i, child := range t.children {
-		id := child.value.String()
-		ordered[i] = id
-		mapped[id] = child
-	}
-
-	slices.SortFunc(ordered, strings.Compare)
-	for _, name := range ordered {
-		child := mapped[name]
-		for line := range strings.Lines(child.String()) {
-			if !root {
-				b.WriteString("  ")
-			}
-			b.WriteString(line)
-		}
-	}
-
-	return b.String()
 }

--- a/internal/github/metadata.go
+++ b/internal/github/metadata.go
@@ -1,0 +1,69 @@
+// Copyright 2025 Eric Cornelissen
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package github
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+)
+
+type apiRepoMetadata struct {
+	Archived bool `json:"archived"`
+}
+
+const apiUrl = "https://api.github.com"
+
+// Archived returns whether the given repository is archived on GitHub.
+func Archived(repo *Repository) (bool, error) {
+	metadata, err := getRepoMetadata(repo)
+	if err != nil {
+		return false, err
+	}
+
+	return metadata.Archived, nil
+}
+
+func getRepoMetadata(repo *Repository) (apiRepoMetadata, error) {
+	var metadata apiRepoMetadata
+
+	url := fmt.Sprintf("%s/repos/%s/%s", apiUrl, repo.Owner, repo.Project)
+	req, _ := http.NewRequest("GET", url, nil)
+
+	req.Header.Add("Accept", "application/vnd.github+json")
+	req.Header.Add("X-GitHub-Api-Version", "2022-11-28")
+	if token, ok := os.LookupEnv("GH_TOKEN"); ok {
+		req.Header.Add("Authorization", "Bearer "+token)
+	}
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return metadata, fmt.Errorf("GET %s failed: %v", url, err)
+	}
+
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return metadata, fmt.Errorf("GET %s failed with status %d", url, resp.StatusCode)
+	}
+
+	err = json.NewDecoder(resp.Body).Decode(&metadata)
+	if err != nil {
+		return metadata, fmt.Errorf("GET %s response malformed: %v", url, err)
+	}
+
+	return metadata, nil
+}

--- a/testdata/list/error.txtar
+++ b/testdata/list/error.txtar
@@ -1,32 +1,32 @@
 # Repo without GitHub Actions
-! exec ghasum list no-actions/
+! exec ghasum list -offline no-actions/
 ! stdout 'Ok'
 stderr 'an unexpected error occurred'
 stderr 'no such file or directory'
 
 # Invalid workflow
-! exec ghasum list invalid-workflow/
+! exec ghasum list -offline invalid-workflow/
 ! stdout 'Ok'
 stderr 'an unexpected error occurred'
 stderr 'could not parse workflow'
 stderr '.github/workflows/workflow.yml'
 
 # Invalid action manifest
-! exec ghasum list -cache .cache/ invalid-manifest/
+! exec ghasum list -offline -cache .cache/ invalid-manifest/
 ! stdout 'Ok'
 stderr 'an unexpected error occurred'
 stderr 'could not parse manifest'
 stderr 'action manifest parsing failed for actions/composite@v1'
 
 # Invalid reusable workflow
-! exec ghasum list -cache .cache/ invalid-reusable-workflow/
+! exec ghasum list -offline -cache .cache/ invalid-reusable-workflow/
 ! stdout 'Ok'
 stderr 'an unexpected error occurred'
 stderr 'could not parse workflow'
 stderr 'reusable workflow parsing failed for actions/reusable/.github/workflows/workflow.yml@v2'
 
 # Directory not found
-! exec ghasum list directory-not-found/
+! exec ghasum list -offline directory-not-found/
 ! stdout 'Ok'
 stderr 'an unexpected error occurred'
 stderr 'no such file or directory'

--- a/testdata/list/success.txtar
+++ b/testdata/list/success.txtar
@@ -1,17 +1,17 @@
 # Example
-exec ghasum list -cache .cache/ target/
+exec ghasum list -offline -cache .cache/ target/
 cmp stdout .want/all.txt
 ! stderr .
 
 # Without transitive actions
-exec ghasum list -cache .cache/ -no-transitive target/
+exec ghasum list -offline -cache .cache/ -no-transitive target/
 cmp stdout .want/no-transitive.txt
 ! stderr .
 
 # Without sumfile
 rm target/.github/workflows/gha.sum
 
-exec ghasum list -cache .cache/ target/
+exec ghasum list -offline -cache .cache/ target/
 cmp stdout .want/all.txt
 ! stderr .
 


### PR DESCRIPTION
Closes #253

## Summary

Adds a way to check for Actions originating from archived repositories with `ghasum list`. This can help users find Actions they should migrate away from.

~~As of the creation of this Pull Request it's implemented as part of `ghasum verify` with the opt-in flag `-archived`. I'm not a fan of this and would rather incorporate it with `ghasum list` (or similar), which means this is blocked by #257.~~