### PR TITLE
Correct `ghasum` verification on Windows-based runners

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -77,7 +77,11 @@ jobs:
       run: |
         $WorkflowParts = $env:WORKFLOW -split '@'
         $WorkflowPath = ($WorkflowParts[0] -split '/')[2..4] -join '/'
-        go run ./cmd/ghasum verify -cache D:\a\_actions -no-evict -offline "${WorkflowPath}:${env:JOB}"
+        if (Test-Path -Path 'C:\a\_actions') {
+          go run ./cmd/ghasum verify -cache C:\a\_actions -no-evict -offline "${WorkflowPath}:${env:JOB}"
+        } else {
+          go run ./cmd/ghasum verify -cache D:\a\_actions -no-evict -offline "${WorkflowPath}:${env:JOB}"
+        }
     - name: Uninitialize ghasum
       run: rm .github/workflows/gha.sum
     - name: Run on this repository


### PR DESCRIPTION
Update this project's own CI to fix a flaky bug with verification of `ghasum` checksums in Windows-based runners. In these runners, apparently, actions may be stored on either the C: or D: drive...

Addresses recent CI failures, namely:

- https://github.com/chains-project/ghasum/actions/runs/16315386993/job/46080203281
- https://github.com/chains-project/ghasum/actions/runs/16315485709/job/46080873357