### PR TITLE
Sync container Go version with system Go version

### DIFF
--- a/Containerfile.dev
+++ b/Containerfile.dev
@@ -17,7 +17,8 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-FROM docker.io/golang:1.24.2-alpine3.21
+ARG GO_VERSION=invalid
+FROM docker.io/golang:${GO_VERSION}-alpine3.22
 
 RUN apk add --no-cache \
 	bash git perl-utils zip \

--- a/tasks.go
+++ b/tasks.go
@@ -32,6 +32,7 @@ import (
 	"os"
 	"os/exec"
 	"regexp"
+	"runtime"
 	"strings"
 )
 
@@ -194,8 +195,9 @@ func TaskDevEnv(t *T) error {
 	var (
 		engine = t.Env("CONTAINER_ENGINE", "docker")
 		build  = fmt.Sprintf(
-			"%s build --file Containerfile.dev --tag ghasum-dev-img .",
+			"%s build --build-arg GO_VERSION=%s --file Containerfile.dev --tag ghasum-dev-img .",
 			engine,
+			runtime.Version()[2:],
 		)
 		run = fmt.Sprintf(
 			"%s run -it --rm --workdir /ghasum --mount 'type=bind,source=%s,target=/ghasum' --name ghasum-dev-env ghasum-dev-img",


### PR DESCRIPTION
## Summary

Update the development container's Go version to be taken as a build argument. The task `go tasks.go dev-env` automatically sets this to the current Go version, which is managed in `go.mod`. This simplifies the setup for intended development, and if the image needs to be build by hand it can still be provided.