### PR TITLE
Improve `ghasum verify` help text and tests

### DIFF
--- a/cmd/ghasum/verify.go
+++ b/cmd/ghasum/verify.go
@@ -33,8 +33,8 @@ func cmdVerify(argv []string) error {
 		flagCache        = flags.String(flagNameCache, "", "")
 		flagNoCache      = flags.Bool(flagNameNoCache, false, "")
 		flagNoEvict      = flags.Bool(flagNameNoEvict, false, "")
-		flagOffline      = flags.Bool(flagNameOffline, false, "")
 		flagNoTransitive = flags.Bool(flagNameNoTransitive, false, "")
+		flagOffline      = flags.Bool(flagNameOffline, false, "")
 	)
 
 	flags.Usage = func() { fmt.Fprintln(os.Stderr) }
@@ -152,10 +152,10 @@ The available flags are:
         Disable the use of the cache. Makes the -cache flag ineffective.
     -no-evict
         Disable cache eviction.
+    -no-transitive
+        Do not verify checksums for transitive actions.
     -offline
         Run without fetching repositories from the internet, verify exclusively
         against the cache. If the cache is missing an entry it causes an error.
-    -no-transitive
-        Do not verify checksums for transitive actions.
 `
 }

--- a/testdata/verify/error.txtar
+++ b/testdata/verify/error.txtar
@@ -1,83 +1,83 @@
 # Repo without GitHub Actions
-! exec ghasum verify no-actions/
+! exec ghasum verify -offline no-actions/
 ! stdout 'Ok'
 stderr 'an unexpected error occurred'
 stderr 'ghasum has not yet been initialized'
 
 # Uninitialized repo with GitHub Actions
-! exec ghasum verify uninitialized/
+! exec ghasum verify -offline uninitialized/
 ! stdout 'Ok'
 stderr 'an unexpected error occurred'
 stderr 'ghasum has not yet been initialized'
 
 # Sumfile with syntax error in headers
-! exec ghasum verify sumfile-syntax-headers/
+! exec ghasum verify -offline sumfile-syntax-headers/
 ! stdout 'Ok'
 stderr 'an unexpected error occurred'
 stderr 'sumfile headers are invalid'
 stderr 'invalid header on line 2'
 
 # Sumfile with syntax error in entries
-! exec ghasum verify sumfile-syntax-entries/
+! exec ghasum verify -offline sumfile-syntax-entries/
 ! stdout 'Ok'
 stderr 'an unexpected error occurred'
 stderr 'syntax error on line 3'
 
 # Sumfile with duplicate headers
-! exec ghasum verify sumfile-duplicate-headers/
+! exec ghasum verify -offline sumfile-duplicate-headers/
 ! stdout 'Ok'
 stderr 'an unexpected error occurred'
 stderr 'sumfile headers are invalid'
 stderr 'duplicate header "foo" on line 3'
 
 # Sumfile with duplicate entries
-! exec ghasum verify sumfile-duplicate-entries/
+! exec ghasum verify -offline sumfile-duplicate-entries/
 ! stdout 'Ok'
 stderr 'an unexpected error occurred'
 stderr 'checksums are corrupted'
 stderr 'duplicate entry found'
 
 # Invalid workflow
-! exec ghasum verify invalid-workflow/
+! exec ghasum verify -offline invalid-workflow/
 ! stdout 'Ok'
 stderr 'an unexpected error occurred'
 stderr 'could not parse workflow'
 stderr '.github/workflows/workflow.yml'
 
 # Invalid manifest
-! exec ghasum verify -cache .cache/ invalid-manifest/
+! exec ghasum verify -offline -cache .cache/ invalid-manifest/
 ! stdout 'Ok'
 stderr 'an unexpected error occurred'
 stderr 'could not parse manifest'
 stderr 'action manifest parsing failed for actions/composite@v1'
 
 # Invalid reusable workflow
-! exec ghasum verify -cache .cache/ invalid-reusable-workflow/
+! exec ghasum verify -offline -cache .cache/ invalid-reusable-workflow/
 ! stdout 'Ok'
 stderr 'an unexpected error occurred'
 stderr 'could not parse workflow'
 stderr 'reusable workflow parsing failed for actions/reusable/.github/workflows/workflow.yml@v2'
 
 # Directory not found
-! exec ghasum verify directory-not-found/
+! exec ghasum verify -offline directory-not-found/
 ! stdout 'Ok'
 stderr 'an unexpected error occurred'
 stderr 'no such file or directory'
 
 # Workflow not found
-! exec ghasum verify initialized/.github/workflows/not-found.yml
+! exec ghasum verify -offline initialized/.github/workflows/not-found.yml
 ! stdout 'Ok'
 stderr 'an unexpected error occurred'
 stderr 'no such file or directory'
 
 # Job not found
-! exec ghasum verify initialized/.github/workflows/workflow.yml:not-found
+! exec ghasum verify -offline initialized/.github/workflows/workflow.yml:not-found
 ! stdout 'Ok'
 stderr 'an unexpected error occurred'
 stderr 'job "not-found" not found in workflow ".github/workflows/workflow.yml"'
 
 # Offline cache entry missing
-! exec ghasum verify -cache .cache/ -offline not-cached/
+! exec ghasum verify -offline -cache .cache/ -offline not-cached/
 ! stdout 'Ok'
 stderr 'an unexpected error occurred'
 stderr 'missing "actions/checkout@not-cached" from cache'

--- a/testdata/verify/problems.txtar
+++ b/testdata/verify/problems.txtar
@@ -1,5 +1,5 @@
 # Checksum mismatch - Repo
-! exec ghasum verify -cache .cache/ mismatch/
+! exec ghasum verify -offline -cache .cache/ mismatch/
 stdout '3 problem\(s\) occurred during validation:'
 stdout 'checksum mismatch for "actions/checkout@v4"'
 stdout 'checksum mismatch for "actions/setup-go@v5"'
@@ -8,7 +8,7 @@ stdout 'checksum mismatch for "actions/setup-java@v4"'
 ! stderr .
 
 # Checksum mismatch - Workflow
-! exec ghasum verify -cache .cache/ mismatch/.github/workflows/workflow.yml
+! exec ghasum verify -offline -cache .cache/ mismatch/.github/workflows/workflow.yml
 stdout '3 problem\(s\) occurred during validation:'
 stdout 'checksum mismatch for "actions/checkout@v4"'
 stdout 'checksum mismatch for "actions/setup-go@v5"'
@@ -17,7 +17,7 @@ stdout 'checksum mismatch for "actions/setup-java@v4"'
 ! stderr .
 
 # Checksum mismatch - Job
-! exec ghasum verify -cache .cache/ mismatch/.github/workflows/workflow.yml:example
+! exec ghasum verify -offline -cache .cache/ mismatch/.github/workflows/workflow.yml:example
 stdout '2 problem\(s\) occurred during validation:'
 stdout 'checksum mismatch for "actions/checkout@v4"'
 stdout 'checksum mismatch for "actions/setup-go@v5"'
@@ -25,21 +25,21 @@ stdout 'checksum mismatch for "actions/setup-go@v5"'
 ! stderr .
 
 # Checksum mismatch - Transitive, manifest
-! exec ghasum verify -cache .cache/ mismatch/.github/workflows/workflow.yml:transitive-manifest
+! exec ghasum verify -offline -cache .cache/ mismatch/.github/workflows/workflow.yml:transitive-manifest
 stdout '1 problem\(s\) occurred during validation:'
 stdout 'checksum mismatch for "actions/setup-go@v5"'
 ! stdout 'Ok'
 ! stderr .
 
 # Checksum mismatch - Transitive, reusable workflow
-! exec ghasum verify -cache .cache/ mismatch/.github/workflows/workflow.yml:transitive-reusable-workflow
+! exec ghasum verify -offline -cache .cache/ mismatch/.github/workflows/workflow.yml:transitive-reusable-workflow
 stdout '1 problem\(s\) occurred during validation:'
 stdout 'checksum mismatch for "actions/setup-java@v4"'
 ! stdout 'Ok'
 ! stderr .
 
 # Checksum missing - Repo
-! exec ghasum verify -cache .cache/ missing/
+! exec ghasum verify -offline -cache .cache/ missing/
 stdout '2 problem\(s\) occurred during validation:'
 stdout 'no checksum found for "actions/setup-go@v5"'
 stdout 'no checksum found for "actions/setup-java@v4"'
@@ -47,7 +47,7 @@ stdout 'no checksum found for "actions/setup-java@v4"'
 ! stderr .
 
 # Checksum missing - Workflow
-! exec ghasum verify -cache .cache/ missing/.github/workflows/workflow.yml
+! exec ghasum verify -offline -cache .cache/ missing/.github/workflows/workflow.yml
 stdout '2 problem\(s\) occurred during validation:'
 stdout 'no checksum found for "actions/setup-go@v5"'
 stdout 'no checksum found for "actions/setup-java@v4"'
@@ -55,35 +55,35 @@ stdout 'no checksum found for "actions/setup-java@v4"'
 ! stderr .
 
 # Checksum missing - Job
-! exec ghasum verify -cache .cache/ missing/.github/workflows/workflow.yml:example
+! exec ghasum verify -offline -cache .cache/ missing/.github/workflows/workflow.yml:example
 stdout '1 problem\(s\) occurred during validation:'
 stdout 'no checksum found for "actions/setup-go@v5"'
 ! stdout 'Ok'
 ! stderr .
 
 # Checksum missing - Transitive, manifest
-! exec ghasum verify -cache .cache/ missing/.github/workflows/workflow.yml:transitive-manifest
+! exec ghasum verify -offline -cache .cache/ missing/.github/workflows/workflow.yml:transitive-manifest
 stdout '1 problem\(s\) occurred during validation:'
 stdout 'no checksum found for "actions/setup-go@v5"'
 ! stdout 'Ok'
 ! stderr .
 
 # Checksum missing - Transitive, reusable workflow
-! exec ghasum verify -cache .cache/ missing/.github/workflows/workflow.yml:transitive-reusable-workflow
+! exec ghasum verify -offline -cache .cache/ missing/.github/workflows/workflow.yml:transitive-reusable-workflow
 stdout '1 problem\(s\) occurred during validation:'
 stdout 'no checksum found for "actions/setup-java@v4"'
 ! stdout 'Ok'
 ! stderr .
 
 # Checksum redundant - Repo
-! exec ghasum verify -cache .cache/ redundant/
+! exec ghasum verify -offline -cache .cache/ redundant/
 stdout '1 problem\(s\) occurred during validation:'
 stdout 'redundant checksum for "actions/reusable@v2"'
 ! stdout 'Ok'
 ! stderr .
 
 # Checksum redundant - Transitive
-! exec ghasum verify -cache .cache/ -no-transitive redundant/
+! exec ghasum verify -offline -cache .cache/ -no-transitive redundant/
 stdout '2 problem\(s\) occurred during validation:'
 stdout 'redundant checksum for "actions/reusable@v2"'
 stdout 'redundant checksum for "actions/setup-go@v5"'

--- a/testdata/verify/success.txtar
+++ b/testdata/verify/success.txtar
@@ -1,42 +1,42 @@
 # Checksums match exactly - Repo
-exec ghasum verify -cache .cache/ up-to-date/
+exec ghasum verify -offline -cache .cache/ up-to-date/
 stdout 'Ok'
 ! stderr .
 
 # Checksums match exactly - Workflow
-exec ghasum verify -cache .cache/ up-to-date/.github/workflows/workflow.yml
+exec ghasum verify -offline -cache .cache/ up-to-date/.github/workflows/workflow.yml
 stdout 'Ok'
 ! stderr .
 
 # Checksums match exactly - Job
-exec ghasum verify -cache .cache/ up-to-date/.github/workflows/workflow.yml:example-1
+exec ghasum verify -offline -cache .cache/ up-to-date/.github/workflows/workflow.yml:example-1
 stdout 'Ok'
 ! stderr .
 
 # Redundant checksum stored - Workflow
-exec ghasum verify -cache .cache/ redundant/.github/workflows/workflow.yml
+exec ghasum verify -offline -cache .cache/ redundant/.github/workflows/workflow.yml
 stdout 'Ok'
 ! stderr .
 
 # Redundant checksum stored - Job
-exec ghasum verify -cache .cache/ redundant/.github/workflows/workflow.yml:example-1
+exec ghasum verify -offline -cache .cache/ redundant/.github/workflows/workflow.yml:example-1
 stdout 'Ok'
 ! stderr .
 
 # Checksums match partially - Workflow
-exec ghasum verify -cache .cache/ partial/.github/workflows/valid.yml
+exec ghasum verify -offline -cache .cache/ partial/.github/workflows/valid.yml
 stdout 'Ok'
 ! stderr .
 
 # Checksums match partially - Job
-exec ghasum verify -cache .cache/ partial/.github/workflows/invalid.yml:valid
+exec ghasum verify -offline -cache .cache/ partial/.github/workflows/invalid.yml:valid
 stdout 'Ok'
 ! stderr .
 
 # Checksums match partially - Sanity check
-! exec ghasum verify -cache .cache/ partial/
-! exec ghasum verify -cache .cache/ partial/.github/workflows/invalid.yml
-! exec ghasum verify -cache .cache/ partial/.github/workflows/invalid.yml:invalid
+! exec ghasum verify -offline -cache .cache/ partial/
+! exec ghasum verify -offline -cache .cache/ partial/.github/workflows/invalid.yml
+! exec ghasum verify -offline -cache .cache/ partial/.github/workflows/invalid.yml:invalid
 
 -- up-to-date/.github/workflows/gha.sum --
 version 1


### PR DESCRIPTION
## Summary

Improve the `ghasum verify` help text (and command logic) by ordering flags alphabetically and its test suite by using the `-offline` flag to help avoid using the network during testing.