### PR TITLE
Refactor cache options, integrate eviction

### DIFF
--- a/cmd/ghasum/cache.go
+++ b/cmd/ghasum/cache.go
@@ -41,7 +41,10 @@ func cmdCache(argv []string) error {
 		return errors.New("only one command can be run at the time")
 	}
 
-	c, err := cache.New(*flagCache, false)
+	c, err := cache.New(
+		cache.WithLocation(*flagCache),
+		cache.WithEviction(false),
+	)
 	if err != nil {
 		return errors.Join(errUnexpected, err)
 	}

--- a/cmd/ghasum/init.go
+++ b/cmd/ghasum/init.go
@@ -48,15 +48,13 @@ func cmdInit(argv []string) error {
 		return err
 	}
 
-	c, err := cache.New(*flagCache, *flagNoCache)
+	c, err := cache.New(
+		cache.WithLocation(*flagCache),
+		cache.WithEviction(!*flagNoEvict),
+		cache.WithEphemeralCache(*flagNoCache),
+	)
 	if err != nil {
 		return errors.Join(errCache, err)
-	}
-
-	if !*flagNoEvict {
-		if _, err = c.Evict(); err != nil {
-			return errors.Join(errCache, err)
-		}
 	}
 
 	repo, err := os.OpenRoot(target)

--- a/cmd/ghasum/list.go
+++ b/cmd/ghasum/list.go
@@ -49,15 +49,13 @@ func cmdList(argv []string) error {
 		return err
 	}
 
-	c, err := cache.New(*flagCache, *flagNoCache)
+	c, err := cache.New(
+		cache.WithLocation(*flagCache),
+		cache.WithEviction(!*flagNoEvict),
+		cache.WithEphemeralCache(*flagNoCache),
+	)
 	if err != nil {
 		return errors.Join(errCache, err)
-	}
-
-	if !*flagNoEvict {
-		if _, err = c.Evict(); err != nil {
-			return errors.Join(errCache, err)
-		}
 	}
 
 	repo, err := os.OpenRoot(target)

--- a/cmd/ghasum/update.go
+++ b/cmd/ghasum/update.go
@@ -50,15 +50,13 @@ func cmdUpdate(argv []string) error {
 		return err
 	}
 
-	c, err := cache.New(*flagCache, *flagNoCache)
+	c, err := cache.New(
+		cache.WithLocation(*flagCache),
+		cache.WithEviction(!*flagNoEvict),
+		cache.WithEphemeralCache(*flagNoCache),
+	)
 	if err != nil {
 		return errors.Join(errCache, err)
-	}
-
-	if !*flagNoEvict {
-		if _, err = c.Evict(); err != nil {
-			return errors.Join(errCache, err)
-		}
 	}
 
 	repo, err := os.OpenRoot(target)

--- a/cmd/ghasum/verify.go
+++ b/cmd/ghasum/verify.go
@@ -71,15 +71,13 @@ func cmdVerify(argv []string) error {
 		target = repo
 	}
 
-	c, err := cache.New(*flagCache, *flagNoCache)
+	c, err := cache.New(
+		cache.WithLocation(*flagCache),
+		cache.WithEviction(!*flagNoEvict),
+		cache.WithEphemeralCache(*flagNoCache),
+	)
 	if err != nil {
 		return errors.Join(errCache, err)
-	}
-
-	if !*flagNoEvict {
-		if _, err = c.Evict(); err != nil {
-			return errors.Join(errCache, err)
-		}
 	}
 
 	repo, err := os.OpenRoot(target)

--- a/internal/cache/options.go
+++ b/internal/cache/options.go
@@ -1,0 +1,55 @@
+// Copyright 2025 Eric Cornelissen
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cache
+
+// Option is a function to configure the cache.
+type Option func(Options) Options
+
+// Options for a [New] cache.
+type Options struct {
+	Location  string
+	Ephemeral bool
+	Evict     bool
+}
+
+var defaultOpts = Options{
+	Ephemeral: false,
+	Evict:     true,
+}
+
+// WithEphemeralCache makes the cache ephemeral (single-run use).
+func WithEphemeralCache(v bool) Option {
+	return func(opts Options) Options {
+		opts.Ephemeral = v
+		return opts
+	}
+}
+
+// WithEviction enables or disabled cache evection.
+func WithEviction(v bool) Option {
+	return func(opts Options) Options {
+		opts.Evict = v
+		return opts
+	}
+}
+
+// WithLocation sets the location of the cache. The location is ignored when the
+// cache is ephemeral.
+func WithLocation(v string) Option {
+	return func(opts Options) Options {
+		opts.Location = v
+		return opts
+	}
+}

--- a/internal/cache/options_test.go
+++ b/internal/cache/options_test.go
@@ -1,0 +1,74 @@
+// Copyright 2025 Eric Cornelissen
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cache
+
+import (
+	"testing"
+	"testing/quick"
+)
+
+func TestWithEphemeralCache(t *testing.T) {
+	t.Parallel()
+
+	got := func(opts Options, v bool) Options {
+		option := WithEphemeralCache(v)
+		return option(opts)
+	}
+
+	want := func(opts Options, v bool) Options {
+		opts.Ephemeral = v
+		return opts
+	}
+
+	if err := quick.CheckEqual(got, want, nil); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestWithEviction(t *testing.T) {
+	t.Parallel()
+
+	got := func(opts Options, v bool) Options {
+		option := WithEviction(v)
+		return option(opts)
+	}
+
+	want := func(opts Options, v bool) Options {
+		opts.Evict = v
+		return opts
+	}
+
+	if err := quick.CheckEqual(got, want, nil); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestWithLocation(t *testing.T) {
+	t.Parallel()
+
+	got := func(opts Options, v string) Options {
+		option := WithLocation(v)
+		return option(opts)
+	}
+
+	want := func(opts Options, v string) Options {
+		opts.Location = v
+		return opts
+	}
+
+	if err := quick.CheckEqual(got, want, nil); err != nil {
+		t.Error(err)
+	}
+}

--- a/internal/ghasum/atoms.go
+++ b/internal/ghasum/atoms.go
@@ -184,6 +184,8 @@ func find(cfg *Config) (tree, error) {
 
 	for i := 0; i < len(actions); i++ {
 		action := actions[i]
+		parent := parents[i]
+
 		actionDir, err := clone(cfg, &action)
 		if err != nil {
 			return root, err
@@ -213,7 +215,7 @@ func find(cfg *Config) (tree, error) {
 			}
 		}
 
-		parents[i].add(&subtree)
+		parent.add(&subtree)
 	}
 
 	return root, nil


### PR DESCRIPTION
## Summary

Update the implementation of the `cache` package, primarily by changing how it is configured - using the Option pattern. Also some updated docs and changes to `New` to hopefully improve readability.

More importantly, this moves cache eviction into the `New` function with the goal of avoiding duplication of this logic in `cmd/ghasum`.