### PR TITLE
Use `fs.FS` to read the sumfile for verification

### DIFF
--- a/internal/ghasum/operations.go
+++ b/internal/ghasum/operations.go
@@ -198,19 +198,9 @@ func Update(cfg *Config, force bool) (UpdateReport, error) {
 func Verify(cfg *Config) (VerifyReport, error) {
 	var report VerifyReport
 
-	file, err := open(cfg.Path)
+	raw, err := read(cfg.Repo)
 	if err != nil {
 		return report, err
-	}
-
-	defer func() {
-		_ = unlock(cfg.Path)
-		_ = file.Close()
-	}()
-
-	raw, err := io.ReadAll(file)
-	if err != nil {
-		return report, errors.Join(ErrSumfileRead, err)
 	}
 
 	stored, err := decode(raw)
@@ -231,10 +221,6 @@ func Verify(cfg *Config) (VerifyReport, error) {
 	reportRedundant := cfg.Workflow == "" && cfg.Job == ""
 	report.Problems = compare(fresh, stored, reportRedundant)
 	report.Total = len(fresh)
-
-	if err := unlock(cfg.Path); err != nil {
-		return report, err
-	}
 
 	return report, nil
 }


### PR DESCRIPTION
## Summary

Avoid one use of the `os` interface in the verification logic as a step towards making the code less dependent on the specific API and more testable. This new atom function can only be used for verification because other functions either don't touch or also write to the sumfile.

I consider the slight duplication (in error handling) worth it for the benefit of using the `fs.FS` interface instead.