### PR TITLE
Reject checksum entries containing carriage return characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,9 @@ Versioning].
 
 ## [Unreleased]
 
-- _No changes yet_
+### Enhancements
+
+- Reject checksum entries containing carriage return characters.
 
 ## [v0.6.1] - 2025-09-20
 

--- a/internal/sumfile/version1.go
+++ b/internal/sumfile/version1.go
@@ -80,11 +80,11 @@ func validV1(entries []Entry) error {
 	}
 
 	for _, entry := range entries {
-		if strings.ContainsAny(entry.Checksum, "\n ") {
+		if strings.ContainsAny(entry.Checksum, "\n\r ") {
 			return ErrSyntax
 		}
 
-		if strings.ContainsAny(strings.Join(entry.ID, ""), "\n @") {
+		if strings.ContainsAny(strings.Join(entry.ID, ""), "\n\r @") {
 			return ErrSyntax
 		}
 	}

--- a/internal/sumfile/version1_test.go
+++ b/internal/sumfile/version1_test.go
@@ -266,6 +266,12 @@ b bb
 					Checksum: "Hello\nworld!",
 				},
 			},
+			"checksum with carriage return": {
+				{
+					ID:       []string{"anything"},
+					Checksum: "Hello\rworld!",
+				},
+			},
 			"checksum with space": {
 				{
 					ID:       []string{"anything"},
@@ -275,6 +281,12 @@ b bb
 			"ID part with newline": {
 				{
 					ID:       []string{"Hello\nworld!"},
+					Checksum: "anything",
+				},
+			},
+			"ID part with carriage return": {
+				{
+					ID:       []string{"Hello\rworld!"},
 					Checksum: "anything",
 				},
 			},


### PR DESCRIPTION
This was detected through flakiness in the `TestAnyVersion` in `sumfile_test.go`, e.g. in <https://github.com/chains-project/ghasum/actions/runs/18454029754/attempts/1>.