### PR TITLE
Bump Go from 1.25.0 to 1.25.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Versioning].
 
 - Reject checksum entries containing carriage return characters.
 
+### Security
+
+- Upgrade Go to `v1.25.3`.
+
 ## [v0.6.1] - 2025-09-20
 
 ### Bugs

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/chains-project/ghasum
 
-go 1.25.0
+go 1.25.3
 
 require (
 	github.com/go-git/go-git/v5 v5.16.1


### PR DESCRIPTION
Relates to [`audit.yml` job #1027](https://github.com/chains-project/ghasum/actions/runs/18928586918/job/54040627112) 

## Summary

Upgrade Go following the release of the [GO-2025-4007](https://pkg.go.dev/vuln/GO-2025-4013) through [GO-2025-4013](https://pkg.go.dev/vuln/GO-2025-4013) advisories affecting Go prior to 1.25.3 (and some 1.25.2) which according to [`govulncheck`](https://pkg.go.dev/golang.org/x/vuln/cmd/govulncheck) affect this project.