### PR TITLE
Bump Go from 1.25.3 to 1.25.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ Versioning].
 
 ### Security
 
-- Upgrade Go to `v1.25.3`.
+- Upgrade Go to `v1.25.5`.
 
 ## [v0.6.1] - 2025-09-20
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/chains-project/ghasum
 
-go 1.25.3
+go 1.25.5
 
 require (
 	github.com/go-git/go-git/v5 v5.16.4


### PR DESCRIPTION
Relates to #306, [audit.yml job #1079](https://github.com/chains-project/ghasum/actions/runs/19881083032)

## Summary

Upgrade Go following the release of the [GO-2025-4155](https://pkg.go.dev/vuln/GO-2025-4155) advisory affecting Go prior to 1.25.5 which according to `govulncheck` affects the project.