### PR TITLE
Bump Go from 1.25.5 to 1.25.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ Versioning].
 
 ## [Unreleased]
 
+### Security
+
+- Upgrade Go to `v1.25.6`.
+
+## [v0.6.3] - 2026-01-07
+
 ### Bug
 
 - Revert handling of mixed case action identifiers.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/chains-project/ghasum
 
-go 1.25.5
+go 1.25.6
 
 require (
 	github.com/go-git/go-git/v5 v5.16.4


### PR DESCRIPTION
Relates to #316, [`audit.yml` job #1173](https://github.com/chains-project/ghasum/actions/runs/21465202876)

## Summary

Upgrade Go following the publication of the GO-2026-4340 advisory affecting Go prior to 1.25.6, which according to `govulncheck` affects this project.