### PR TITLE
Bump Go from 1.25.6 to 1.25.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Versioning].
 
 ### Security
 
-- Upgrade Go to `v1.25.6`.
+- Upgrade Go to `v1.25.7`.
 
 ## [v0.6.3] - 2026-01-07
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/chains-project/ghasum
 
-go 1.25.6
+go 1.25.7
 
 require (
 	github.com/go-git/go-git/v5 v5.16.4


### PR DESCRIPTION
Relates to #356, [Audit job #1193](https://github.com/chains-project/ghasum/actions/runs/21738411036)

## Summary

Upgrade Go following the publication of the GO-2026-4337 advisory affecting Go prior to 1.25.7, which according to `govulncheck` affects this project.