### PR TITLE
Bump Go from 1.26.1 to 1.26.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,8 @@ Versioning].
 
 ### Security
 
-- Upgrade Go to `v1.26.1`.
-- Upgrade go-git from to 5.17.1.
+- Upgrade Go to `v1.26.2`.
+- Upgrade go-git to `v5.17.1`.
 
 ## [v0.6.3] - 2026-01-07
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/chains-project/ghasum
 
-go 1.26.1
+go 1.26.2
 
 require (
 	github.com/go-git/go-git/v5 v5.17.2


### PR DESCRIPTION
Relates to #390, [Audit job #1323](https://github.com/chains-project/ghasum/actions/runs/24117898660)

## Summary

Bump Go following GO-2026-4947, GO-2026-4946, GO-2026-4870, and GO-2026-4866 which affect this project according to [`govulncheck`](https://pkg.go.dev/golang.org/x/vuln/cmd/govulncheck).