### PR TITLE
Bump Go from 1.26.2 to 1.26.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Versioning].
 
 ### Security
 
-- Upgrade Go to `v1.26.2`.
+- Upgrade Go to `v1.26.3`.
 - Upgrade go-git to `v5.18.0`.
 
 ## [v0.6.3] - 2026-01-07

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/chains-project/ghasum
 
-go 1.26.2
+go 1.26.3
 
 require (
 	github.com/go-git/go-git/v5 v5.18.0


### PR DESCRIPTION
Relates to #413, [Audit job #1375](https://github.com/chains-project/ghasum/actions/runs/25537454613)

Due to GO-2026-4971 and GO-2026-4918 as determined by govulncheck.