### PR TITLE
Bump Go to v1.26.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Versioning].
 
 ### Security
 
+- Upgrade Go to `v1.26.6`.
 - Upgrade go-git to `v5.19.2`.
 
 ## [v0.6.4] - 2026-08-01

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/chains-project/ghasum
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/go-git/go-git/v5 v5.19.2


### PR DESCRIPTION
Notified by [Audit #1558](https://github.com/chains-project/ghasum/actions/runs/31768731846)
Relates to #469
Due to GO-2026-5026, GO-2026-5972, GO-2026-6090, and GO-2026-6218